### PR TITLE
Add travis configuration

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,7 @@
+[run]
+omit=
+	setup.py
+	manage.py
+	*/test/*
+	smswebapp/settings/*
+	smswebapp/wsgi.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+# We require "sudo" since we're running a docker container.
+# See: https://docs.travis-ci.com/user/docker/
+sudo: required
+services:
+  - docker
+
+language: python
+
+env:
+  global:
+    - DJANGO_DB_ENGINE=django.db.backends.postgresql
+    - DJANGO_DB_NAME=postgres
+    - DJANGO_DB_HOST=localhost
+    - DJANGO_DB_USER=postgres
+    - DJANGO_DB_PASSWORD=mysecret
+
+# Pull and launch the postgres database container.
+before_install:
+  - docker pull postgres:9.6
+  - docker run -d -P -e POSTGRES_PASSWORD=$DJANGO_DB_PASSWORD postgres:9.6
+  - docker ps -a
+
+install:
+  - pip install tox coveralls
+
+script:
+  - tox
+
+after_success:
+  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ services:
 
 language: python
 
+# This should match the version run by tox.
+python:
+  - "3.6"
+
 env:
   global:
     - DJANGO_DB_ENGINE=django.db.backends.postgresql

--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 [![Documentation
 Status](https://readthedocs.org/projects/uis-smswebapp/badge/?version=latest)](http://uis-smswebapp.readthedocs.io/en/latest/?badge=latest)
-[![CircleCI](https://circleci.com/gh/uisautomation/sms-webapp.svg?style=svg)](https://circleci.com/gh/uisautomation/sms-webapp)
+[![Build
+Status](https://travis-ci.org/uisautomation/sms-webapp.svg?branch=master)](https://travis-ci.org/rjw57/sms-webapp)
 [![Coverage
 Status](https://coveralls.io/repos/github/uisautomation/sms-webapp/badge.svg?branch=master)](https://coveralls.io/github/uisautomation/sms-webapp?branch=master)
 

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -35,7 +35,7 @@ build only the documentation:
 
 .. note::
 
-    The CircleCI job runs tox configured with a PostgreSQL database to match
+    The Travis CI job runs tox configured with a PostgreSQL database to match
     that deployed in production. To replicate this, either run a PostgreSQL
     instance on the local machine, use the Google Cloud SQL proxy or :any:`run
     the tests via docker-compose <docker-tox>`.
@@ -146,30 +146,25 @@ pull request. The main rationale for this is a) it guards against accidentally
 ``git push``-ing the wrong branch and b) it reduces the number of "dangling"
 branches in the main repository.
 
-.. _circleci:
+.. _travisci:
 
 Unit tests
 ``````````
 
-The project is set up on `CircleCI <https://circleci.com/>`_ to automatically
+The project is set up on `Travis CI <https://travis-ci.org/>`_ to automatically
 run unit tests and build documentation on each commit to a branch and on each
-pull request. Some items to note:
-
-* The `project dashboard
-  <https://circleci.com/bb/uisautomation/sms-webapp>`_ on CircleCI lists all
-  builds.
-* Individual builds save two artifacts: a HTML code-coverage report and a build
-  copy of the documentation. Both may be viewed from the "artifacts" tab on an
-  individual build's page.
-* By logging into CircleCI via GitHub, you can enable CircleCI for your
-  personal fork. This is **highly recommended** as you'll get rapid feedback via
-  email if you push a commit to a branch which does not pass the test suite.
+pull request.
 
 .. note::
 
-    In order to better match production, CircleCI is set up to run unit tests
-    using the PostgreSQL database and *not* sqlite. If you only run unit tests
-    locally with sqlite then it is possible that some tests may fail.
+    By logging into Travis CI via GitHub, you can enable Travis CI for your
+    personal fork. This is **highly recommended** as you'll get rapid feedback
+    via email if you push a commit to a branch which does not pass the test
+    suite.
+
+In order to better match production, Travis CI is set up to run unit tests using
+the PostgreSQL database and *not* sqlite. If you only run unit tests locally
+with sqlite then it is possible that some tests may fail.
 
 Code-style
 ``````````

--- a/doc/gettingstarted.rst
+++ b/doc/gettingstarted.rst
@@ -21,9 +21,7 @@ fork:
 
 1. Add your repository to `Coveralls <https://coveralls.io/>`_ and make a note
    of the repository token which is generated.
-2. Add your repository to  `CircleCI <https://circleci.com/>`_. Make sure to
-   configure the environment variable ``COVERALLS_REPO_TOKEN`` with the
-   coveralls repository token noted earlier.
+2. Add your repository to  `Travis C <https://travis-ci.org/>`_.
 
 Clone the repository locally
 ````````````````````````````

--- a/smswebapp/settings/tox.py
+++ b/smswebapp/settings/tox.py
@@ -4,6 +4,8 @@ specific to the test suite environment. The default ``tox`` test environment
 uses this settings module when running the test suite.
 
 """
+import copy
+import json
 import os
 
 # Import settings from the base settings file
@@ -17,3 +19,12 @@ TEST_RUNNER = 'smswebapp.test.runner.BufferedDiscoverRunner'
 #: Static files are collected into a directory determined by the tox
 #: configuration. See the tox.ini file.
 STATIC_ROOT = os.environ.get('TOX_STATIC_ROOT')
+
+# When running under tox, it is useful to see the database config. Make a deep copy and censor the
+# password.
+_db_copy = copy.deepcopy(DATABASES)  # noqa: F405
+for v in _db_copy.values():
+    if 'PASSWORD' in v:
+        v['PASSWORD'] = '<redacted>'
+print('Databases:')
+print(json.dumps(_db_copy, indent=2))


### PR DESCRIPTION
Make a simple travis configuration which runs a PostgreSQL container and runs tox with the PostgreSQL container used as the database. To aid debugging, the database config is printed out when tox runs.

Stop reporting coverage on files which should not be reported. See a5b518b.