### PR TITLE
README: fix build status link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Documentation
 Status](https://readthedocs.org/projects/uis-smswebapp/badge/?version=latest)](http://uis-smswebapp.readthedocs.io/en/latest/?badge=latest)
 [![Build
-Status](https://travis-ci.org/uisautomation/sms-webapp.svg?branch=master)](https://travis-ci.org/rjw57/sms-webapp)
+Status](https://travis-ci.org/uisautomation/sms-webapp.svg?branch=master)](https://travis-ci.org/uisautomation/sms-webapp)
 [![Coverage
 Status](https://coveralls.io/repos/github/uisautomation/sms-webapp/badge.svg?branch=master)](https://coveralls.io/github/uisautomation/sms-webapp?branch=master)
 


### PR DESCRIPTION
The build status link was pointing to my fork, not the actual repo.
(D'oh!)