### PR TITLE
Add built documentation to GitHub pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,14 @@ script:
 after_success:
   - codecov
   - coveralls
+
+# From: https://docs.travis-ci.com/user/deployment/pages/
+deploy:
+    provider: pages
+    skip_cleanup: true
+    github_token: $GITHUB_TOKEN
+    local_dir: build/doc/
+    email: automation@uis.cam.ac.uk
+    name: Automation Bot
+    on:
+      branch: master

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Streaming Media Service Webapp
 
-[![Documentation
-Status](https://readthedocs.org/projects/uis-smswebapp/badge/?version=latest)](http://uis-smswebapp.readthedocs.io/en/latest/?badge=latest)
 [![Build
 Status](https://travis-ci.org/uisautomation/sms-webapp.svg?branch=master)](https://travis-ci.org/uisautomation/sms-webapp)
 [![codecov](https://codecov.io/gh/uisautomation/sms-webapp/branch/master/graph/badge.svg)](https://codecov.io/gh/uisautomation/sms-webapp)

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ Status](https://travis-ci.org/uisautomation/sms-webapp.svg?branch=master)](https
 Status](https://coveralls.io/repos/github/uisautomation/sms-webapp/badge.svg?branch=master)](https://coveralls.io/github/uisautomation/sms-webapp?branch=master)
 
 Documentation for developers, including a "getting started" guide, can be found
-at https://uis-smswebapp.readthedocs.org/.
+at https://uisautomation.github.io/sms-webapp.

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 Status](https://readthedocs.org/projects/uis-smswebapp/badge/?version=latest)](http://uis-smswebapp.readthedocs.io/en/latest/?badge=latest)
 [![Build
 Status](https://travis-ci.org/uisautomation/sms-webapp.svg?branch=master)](https://travis-ci.org/uisautomation/sms-webapp)
-[![Coverage
-Status](https://coveralls.io/repos/github/uisautomation/sms-webapp/badge.svg?branch=master)](https://coveralls.io/github/uisautomation/sms-webapp?branch=master)
+[![codecov](https://codecov.io/gh/uisautomation/sms-webapp/branch/master/graph/badge.svg)](https://codecov.io/gh/uisautomation/sms-webapp)
 
 Documentation for developers, including a "getting started" guide, can be found
 at https://uisautomation.github.io/sms-webapp.

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -166,6 +166,27 @@ In order to better match production, Travis CI is set up to run unit tests using
 the PostgreSQL database and *not* sqlite. If you only run unit tests locally
 with sqlite then it is possible that some tests may fail.
 
+Code-coverage
+`````````````
+
+Going to `CodeCov <https://codecov.io/>`_, logging in with GitHub and adding the
+``sms-webapp`` repository will start code coverage reporting on pull-requests.
+
+Documentation
+`````````````
+
+Travis CI has been set up so that when the master branch is built, the
+documentation is deployed to https://uisautomation.github.io/sms-webapp via
+GitHub pages. The `UIS robot <https://github.com/bb9e/>_` machine account's
+personal token is set up in Travis via the ``GITHUB_TOKEN`` environment
+variable.
+
+.. seealso::
+
+    Travis CI's `documentation
+    <https://docs.travis-ci.com/user/deployment/pages/>`_ on deploying to GitHub
+    pages.
+
 Code-style
 ``````````
 


### PR DESCRIPTION
Update the Travis configuration to deploy the built documentation via GitHub pages when the master branch is built. A personal access token for @bb9e has already been added to the Travis for sms-webapp via the GITHUB_TOKEN environment variable so the documentation should build when this PR is merged.