### PR TITLE
doc: add "githubpages" sphinx extension

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,7 +31,7 @@
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = ['sphinx.ext.autodoc']
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.githubpages']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
GitHub pages uses jekyll as a static site builder which doesn't
interact well with directory names generated by Sphinx such as
"_static". Add the githubpages Sphinx extension which adds a ".nojekyll"
file to the output which stops GitHub trying to compile our static site.

See also:
https://help.github.com/articles/files-that-start-with-an-underscore-are-missing/