### PR TITLE
settings.base: take SECRET_KEY from the environment

### DIFF
--- a/compose/base.env
+++ b/compose/base.env
@@ -7,6 +7,9 @@ PORT=8080
 # Use the developer-specific settings.
 DJANGO_SETTINGS_MODULE=smswebapp.settings.developer
 
+# Set the secret key.
+DJANGO_SECRET_KEY=ex561uglj%!8oh*umt3-@2-4yj*&dc8cznob*vmb0!9bryoc-$
+
 # Database configuration. Note that the postgres container also uses these
 # values with differing names.
 DJANGO_DB_ENGINE=django.db.backends.postgresql

--- a/smswebapp/settings/base.py
+++ b/smswebapp/settings/base.py
@@ -5,8 +5,9 @@ import os
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-#: SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'ex561uglj%!8oh*umt3-@2-4yj*&dc8cznob*vmb0!9bryoc-$'
+#: The Django secret key is by default set from the environment. If omitted, a system check will
+#: complain.
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY')
 
 #: SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True

--- a/tox.ini
+++ b/tox.ini
@@ -43,6 +43,7 @@ passenv=
 # DJANGO_SETTINGS_MODULE will not override it.
 setenv=
     DJANGO_SETTINGS_MODULE={env:TOX_DJANGO_SETTINGS_MODULE:smswebapp.settings.tox}
+    DJANGO_SECRET_KEY=ex561uglj%!8oh*umt3-@2-4yj*&dc8cznob*vmb0!9bryoc-$
     DJANGO_DB_ENGINE={env:DJANGO_DB_ENGINE:django.db.backends.sqlite3}
     DJANGO_DB_NAME={env:DJANGO_DB_NAME:{envtmpdir}/testsuite-db.sqlite3}
     TOX_STATIC_ROOT={[_vars]build_root}/static


### PR DESCRIPTION
Instead of hard-coding the SECRET_KEY, take it from the environment
variables. Fix up the tox and docker-compose configurations to set the
variable.

Closes #26.