### PR TITLE
tox: fix reporting of coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,3 +5,4 @@ omit=
 	*/test/*
 	smswebapp/settings/*
 	smswebapp/wsgi.py
+	.tox/*

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ setenv=
 # How to run the test suite. Note that arguments passed to tox are passed on to
 # the test command.
 commands=
-    coverage run --source={toxinidir} --omit={toxworkdir}/* ./manage.py test {posargs}
+    coverage run --source={toxinidir} ./manage.py test {posargs}
     coverage html --directory {[_vars]build_root}/htmlcov/
     coverage report
 


### PR DESCRIPTION
tox.ini specified that the --omit flag be passed to coverage which has the effect of negating the configuration in .coveragerc and caused false-fails with CodeCov. Use the same approach we have in other projects and remote the --omit flag.