### PR TITLE
docker-compose: fix bind volume mount bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     # to allow local changes to be reflected without having to re-build the
     # container.
     volumes:
-      - type: volume
+      - type: bind
         source: ./
         target: /usr/src/app
         read_only: true
@@ -30,7 +30,7 @@ services:
       - compose/base.env
       - compose/tox.env
     volumes:
-      - type: volume
+      - type: bind
         source: ./
         target: /usr/src/app
         read_only: true


### PR DESCRIPTION
In other docker-compose projects we have encountered a similar error to this error which I have just encountered:

```
ERROR: Named volume "{u'read_only': True, u'source': '.', u'type': 'volume', u'target': '/usr/src/app'}" is used in service "devserver" but no declaration was found in the volumes section.
```

We have found that explicitly noting that those volumes are *bind* volumes fixes this problem.

This PR applies the same fix to our docker-compose.yml file which was (possibly) one of the earliest written and does not have this fix.