### PR TITLE
Add RSS endpoint for media items

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,7 @@ omit=
 	setup.py
 	manage.py
 	*/test/*
+	*/tests/*
 	smswebapp/settings/*
 	smswebapp/wsgi.py
 	.tox/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,7 @@ requests-oauthlib
 
 # To interact with the jwplatform API
 jwplatform
+pyjwt
 
 # For an improved ./manage.py shell experience
 ipython

--- a/smsjwplatform/jwplatform.py
+++ b/smsjwplatform/jwplatform.py
@@ -119,7 +119,7 @@ def parse_custom_field(expected_type, field):
     Raises ValueError if the field is of the wrong form or type.
     """
     field_parts = field.split(":")
-    if len(field_parts) != 3 or field_parts[0] != expected_type  or field_parts[2] != '':
+    if len(field_parts) != 3 or field_parts[0] != expected_type or field_parts[2] != '':
         raise ValueError(f"expected format '{expected_type}:value:")
 
     return field_parts[1]

--- a/smsjwplatform/jwplatform.py
+++ b/smsjwplatform/jwplatform.py
@@ -3,11 +3,13 @@ Interaction with the JWPlatform API.
 
 """
 import hashlib
+import math
 import time
 import urllib.parse
 
 from django.conf import settings
 import jwplatform
+import jwt
 
 
 class VideoNotFoundError(RuntimeError):
@@ -150,3 +152,54 @@ def signed_url(url):
     return urllib.parse.urljoin(url, '?' + urllib.parse.urlencode({
         'exp': expiry_timestamp, 'sig': signature
     }))
+
+
+def generate_token(resource):
+    """
+    Generate a signed JWT for the specified resource using the
+    `procedure
+    <https://developer.jwplayer.com/jw-platform/docs/developer-guide/delivery-api/url-token-signing/>`_
+    outlined in the JWPlatform documentation.
+
+    """
+    # The following is lifted almost verbatim from JWPlatform's documentation.
+
+    # Link is valid for 1hr but normalized to 3 minutes to promote better caching
+    exp = math.ceil((time.time() + 3600)/180) * 180
+    token_body = {"resource": resource, "exp": exp}
+
+    return jwt.encode(token_body, settings.JWPLATFORM_API_SECRET, algorithm='HS256')
+
+
+def pd_api_url(resource, **parameters):
+    """
+    Return a JWPlatform Platform Delivery API URL with the request has the appropriate JWT
+    attached.
+
+    :param str resource: path to resource, e.g. ``/v2/media/123456``. Must start with a slash.
+    :param dict parameters: remaining keyword arguments are passed as URL parameters
+    :return: response from API server.
+    :rtype: requests.Response
+
+    :raises ValueError: if the resource name does not start with a slash.
+
+    .. seealso::
+
+        Platform Delivery API reference at
+        https://developer.jwplayer.com/jw-platform/docs/delivery-api-reference/.
+    """
+    # Validate the resource parameter
+    if not resource.startswith('/'):
+        raise ValueError('Resource name must have leading slash')
+
+    # Construct parameters for URL including JWT
+    url_params = {'token': generate_token(resource)}
+    url_params.update(parameters)
+
+    # Construct GET URL
+    url = urllib.parse.urljoin(
+        settings.JWPLATFORM_API_BASE_URL,
+        resource + '?' + urllib.parse.urlencode(url_params)
+    )
+
+    return url

--- a/smsjwplatform/tests/test_jwplatform.py
+++ b/smsjwplatform/tests/test_jwplatform.py
@@ -18,14 +18,14 @@ class JWPlatformTest(TestCase):
         client = mock.Mock()
 
         client.videos.show.return_value = {
-            'video' : {'custom': {'sms_acl': 'acl:WORLD,USER_mb2174:'}}
+            'video': {'custom': {'sms_acl': 'acl:WORLD,USER_mb2174:'}}
         }
         self.assertEqual(get_acl(123, client=client), ['WORLD', 'USER_mb2174'])
 
         client.videos.show.assert_called_with(video_key=123)
 
         client.videos.show.return_value = {
-            'video' : {'custom': {'sms_acl': 'corrupted'}}
+            'video': {'custom': {'sms_acl': 'corrupted'}}
         }
 
         with self.assertRaises(ValueError):

--- a/smsjwplatform/urls.py
+++ b/smsjwplatform/urls.py
@@ -22,4 +22,5 @@ from . import views
 app_name = 'smsjwplatform'
 urlpatterns = [
     path('embed/<int:media_id>/', views.embed, name='embed'),
+    path('rss/media/<int:media_id>/', views.rss_media, name='rss_media'),
 ]

--- a/smsjwplatform/views.py
+++ b/smsjwplatform/views.py
@@ -4,7 +4,7 @@ Views provided by :py:mod:`smsjwplatform`.
 """
 from django.conf import settings
 from django.http import Http404
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 
 from smsjwplatform.acl import build_acl
 from . import jwplatform as api
@@ -42,6 +42,15 @@ def embed(request, media_id):
     return render(request, 'smsjwplatform/embed.html', {
         'embed_url': url,
     })
+
+
+def rss_media(request, media_id):
+    try:
+        key = api.key_for_media_id(media_id, preferred_media_type='video')
+    except api.VideoNotFoundError:
+        raise Http404('Media item does not exist')
+
+    return redirect(api.pd_api_url(f'/v2/media/{key}', format='mrss'))
 
 
 def has_permission(user, key):


### PR DESCRIPTION
JWPlatform supports directly rendering an (m)RSS feed for a given item by means of its platform delivery API. This API has a (third) method for authentication so, firstly, 0a2528f implements that method anf then 52b16cc uses it to add the endpoint. The endpoint simply redirects to the (signed) URL.