### PR TITLE
enable flake8 testing

### DIFF
--- a/smsjwplatform/admin.py
+++ b/smsjwplatform/admin.py
@@ -1,3 +1,3 @@
-from django.contrib import admin
+# from django.contrib import admin
 
 # Register your models here.

--- a/smsjwplatform/defaultsettings.py
+++ b/smsjwplatform/defaultsettings.py
@@ -40,7 +40,7 @@ Base URL for the JWPlatform API. This can usually be left at its default value.
 
 JWPLATFORM_EMBED_PLAYER_KEY = None
 """
-Player key for the embedded player used by the :py:mod:`~.views.embed` view. 
+Player key for the embedded player used by the :py:mod:`~.views.embed` view.
 
 """
 
@@ -94,7 +94,7 @@ lookup resource for a person in seconds.
 
 LOOKUP_PEOPLE_ID_SCHEME = 'mock'
 """
-The ID scheme to use when querying people in LOOKUP. This is almost always 'crsid' unless you are 
+The ID scheme to use when querying people in LOOKUP. This is almost always 'crsid' unless you are
 using test raven, in which case it is 'mock'.
 
 """

--- a/smsjwplatform/models.py
+++ b/smsjwplatform/models.py
@@ -1,3 +1,3 @@
-from django.db import models
+# from django.db import models
 
 # Create your models here.

--- a/smsjwplatform/oauth2client.py
+++ b/smsjwplatform/oauth2client.py
@@ -1,6 +1,6 @@
 """
-The :py:mod:`smsjwplatform.oauth2client` module provides a wrapper around :py:class:`requests.Session`
-which is pre-authorised with an OAuth2 client token.
+The :py:mod:`smsjwplatform.oauth2client` module provides a wrapper around
+:py:class:`requests.Session` which is pre-authorised with an OAuth2 client token.
 
 """
 from django.conf import settings

--- a/smsjwplatform/tests/test_views.py
+++ b/smsjwplatform/tests/test_views.py
@@ -68,7 +68,9 @@ class EmbedTest(TestCase):
 
         """
         with patched_client() as jwclient:
-            jwclient.videos.show.return_value = {'video': {'custom': {'sms_acl': 'acl:USER_mb2174:'}}}
+            jwclient.videos.show.return_value = {
+                'video': {'custom': {'sms_acl': 'acl:USER_mb2174:'}}
+            }
             r = self.client.get(reverse('smsjwplatform:embed', kwargs={'media_id': 34}))
             self.assertEqual(r.status_code, 200)
             self.assertTemplateUsed(r, 'smsjwplatform/401.html')

--- a/tox.ini
+++ b/tox.ini
@@ -73,7 +73,7 @@ deps=
     flake8=={env:TOXINI_FLAKE8_VERSION:3.5.0}
 commands=
     flake8 --version
-    flake8 smswebapp doc
+    flake8 .
 
 # Collect static files
 [testenv:collectstatic]


### PR DESCRIPTION
As noted in #53, the PEP8 tests were only running on a subset of the code. This is fixed by d016a6a. The preceding commit, 7d216dc, fixes the issues which were not previously being caught.

Closes #53.