### PR TITLE
Change uses of JWP management API to use CachedResource

### DIFF
--- a/api/views.py
+++ b/api/views.py
@@ -5,6 +5,7 @@ Views implementing the API endpoints.
 import copy
 import logging
 
+from django.db.models import Q
 from django.conf import settings
 from drf_yasg.utils import swagger_auto_schema
 from rest_framework.exceptions import APIException
@@ -12,6 +13,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from smsjwplatform import jwplatform
+from smsjwplatform.models import CachedResource
 
 from . import serializers
 
@@ -112,47 +114,58 @@ class MediaListView(APIView):
     Endpoint to retrieve a list of media.
 
     """
+    # Mapping from order_by values to SQL expression giving the appropriate value to order results
+    # by.
+    ORDER_BY_MAP = {
+        'date': "data -> 'date'",
+    }
+
     @swagger_auto_schema(
         query_serializer=serializers.MediaListQuerySerializer(),
         responses={200: serializers.MediaListSerializer()}
     )
     def get(self, request):
         """Handle GET request."""
-        client = jwplatform.get_jwplatform_client()
-
         query_serializer = serializers.MediaListQuerySerializer(data=request.query_params)
         query_serializer.is_valid(raise_exception=True)
+        query = query_serializer.data
 
-        params = {}
+        limit, offset = 100, 0
 
-        # Add default parameters
-        params.update({
-            'order_by': '{order_by}:{direction}'.format(**query_serializer.data),
-            'result_limit': 100,
-        })
+        # Django has limited understanding of how to order by a JSONField so we help it out a bit
+        # here by using the .extra() method on the QuerySet and just providing the SQL expression
+        # directly.
+        videos = CachedResource.videos.extra(
+            select={'__ordering': self.ORDER_BY_MAP[query['order_by']]},
+            order_by=[
+                '{}__ordering'.format('-' if query['direction'] == 'desc' else '')
+            ]
+        )
 
-        # Add parameters from query
-        for key in ['search']:
-            if query_serializer.data.get(key) is not None:
-                params[key] = query_serializer.data[key]
-
-        # Add parameters which cannot be overridden
-        params.update({
-            'statuses_filter': 'ready',
-            'http_method': 'POST',
-        })
-
-        # Create a shallow copy of the response because we modify it below
-        video_list = copy.copy(check_api_call(jwplatform.Video.list(params, client=client)))
+        # If the search field is populated, match on title and description. We can be cleverer here
+        # and, for example, use Postgres' support for full text search:
+        # https://www.postgresql.org/docs/current/static/textsearch.html
+        search = query.get('search')
+        if search is not None:
+            videos = videos.filter(
+                Q(data__title__icontains=search) |
+                Q(data__description__icontains=search)
+            )
 
         # Filter videos. They must have a) an SMS media id (so have originated on the SMS) and b)
         # have an ACL which allows the current user.
-        video_list['videos'] = [
-            video for video in video_list['videos']
-            if video.media_id is not None and user_can_view_resource(request.user, video)
-        ]
+        video_list = [jwplatform.Video(video.data) for video in videos.all()[offset:offset+limit]]
+        response = {
+            'videos': [
+                video for video in video_list
+                if video.media_id is not None and user_can_view_resource(request.user, video)
+            ],
+            'limit': limit,
+            'offset': offset,
+            'total': videos.count(),
+        }
 
-        return Response(serializers.MediaListSerializer(video_list).data)
+        return Response(serializers.MediaListSerializer(response).data)
 
 
 def user_can_view_resource(user, resource):

--- a/api/views.py
+++ b/api/views.py
@@ -135,6 +135,8 @@ class MediaListView(APIView):
         # Django has limited understanding of how to order by a JSONField so we help it out a bit
         # here by using the .extra() method on the QuerySet and just providing the SQL expression
         # directly.
+        # Django will have native support for order_by in JSONFields from Django 2.1
+        # To keep track of the issue: https://code.djangoproject.com/ticket/24747
         videos = CachedResource.videos.extra(
             select={'__ordering': self.ORDER_BY_MAP[query['order_by']]},
             order_by=[

--- a/smsjwplatform/jwplatform.py
+++ b/smsjwplatform/jwplatform.py
@@ -14,6 +14,7 @@ import jwplatform
 import jwt
 
 from . import acl
+from . import models
 
 
 class VideoNotFoundError(RuntimeError):
@@ -129,60 +130,53 @@ class Video(Resource):
         """
         Return a :py:class:`Video` instance corresponding to the JWPlatform key passed.
 
+        .. note::
+
+            This method looks for videos by way of the
+            :py:class:`~smsjwplatform.models.CachedResource` model and *not* by using the API
+            directly.
+
         :param key: JWPlatform key for the media.
-        :param client: (optional) an authenticated JWPlatform client as returned by
-            :py:func:`.get_jwplatform_client`. If ``None``, call :py:func:`.get_jwplatform_client`.
 
-        :raises: :py:exc:`jwplatform.errors.JWPlatformNotFoundError` if the video is not found.
+        :raises: :py:exc:`~.VideoNotFoundError` if the video is not found.
 
         """
-        client = client if client is not None else get_jwplatform_client()
-        return cls(client.videos.show(video_key=key)['video'])
+        try:
+            return cls(models.CachedResource.videos.get(key=key).data)
+        except models.CachedResource.DoesNotExist:
+            raise VideoNotFoundError()
 
     @classmethod
-    def list(cls, list_params={}, client=None):
-        """
-        Convenience wrapper around the ``videos.list`` JWPlatform API method. The videos returned
-        are coerced into :py:class:`Video` instances.
-
-        """
-        client = client if client is not None else get_jwplatform_client()
-        response = client.videos.list(**list_params)
-
-        if 'videos' in response:
-            response['videos'] = [cls(resource) for resource in response['videos']]
-
-        return response
-
-    @classmethod
-    def from_media_id(cls, media_id, preferred_media_type='video', client=None):
+    def from_media_id(cls, media_id, preferred_media_type='video'):
         """
         Return a :py:class:`Video` instance which matches the passed legacy SMS media ID or raise
         :py:exc:`VideoNotFoundError` if no such video could be found.
+
+        .. note::
+
+            This method looks for videos by way of the
+            :py:class:`~smsjwplatform.models.CachedResource` model and *not* by using the API
+            directly.
 
         :param media_id: the SMS media ID of the required video
         :type media_id: int
         :param preferred_media_type: (optional) the preferred media type to return. One of
             ``'video'`` or ``'audio'``.
-        :param client: (options) an authenticated JWPlatform client as returned by
-            :py:func:`.get_jwplatform_client`. If ``None``, call :py:func:`.get_jwplatform_client`.
         :raises: :py:class:`.VideoNotFoundError` if the media id does not correspond to a
             JWPlatform video.
 
         """
-        client = client if client is not None else get_jwplatform_client()
-
         # The value of the sms_media_id custom property we search for
         media_id_value = 'media:{:d}:'.format(media_id)
 
         # Search for videos
-        response = client.videos.list(**{
-            'search:custom.sms_media_id': media_id_value,
-        })
+        videos = (v.data for v in models.CachedResource.videos.filter(
+            data__custom__sms_media_id=media_id_value
+        ))
 
         # Loop through "videos" to find the preferred one based on mediatype
         video_resource = None
-        for video_dict in response.get('videos', []):
+        for video_dict in videos:
             # Convert video dictionary to video resource object
             video = cls(video_dict)
 


### PR DESCRIPTION
This PR changes two uses of the JWP management API which were on the critical path of serving resources to users to make use of the CachedResource database objects.

Closes #68.