### PR TITLE
Add an "alpha" banner to the top of the page

### DIFF
--- a/frontend/src/components/AppBar.js
+++ b/frontend/src/components/AppBar.js
@@ -67,9 +67,9 @@ const AppBar = (
   <MuiAppBar position="static" color={color} className={classes.root} {...otherProps}>
     <Grid container component={Toolbar}>
       <Grid item xs={3} className={classes.appBarLeft}>
-          <Typography variant="title" color="inherit">
-            Media&nbsp;Service
-          </Typography>
+        <Typography variant="title" color="inherit">
+          University Media Platform
+        </Typography>
       </Grid>
       <Grid item xs={12} sm={9} md={6} className={classes.appBarMiddle}>
         <SearchForm

--- a/frontend/src/components/MotdBanner.js
+++ b/frontend/src/components/MotdBanner.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Typography from '@material-ui/core/Typography';
+import Divider from '@material-ui/core/Divider';
+import { withStyles } from '@material-ui/core/styles';
+
+import ReleaseTag from './ReleaseTag';
+
+/**
+ * The "message of the day" banner used to display information from the admins to the users.
+ *
+ * Any unknown properties supplied will be spread to the root component.
+ */
+const MotdBanner = ({
+  classes, component: Component, ...otherProps
+}) => (
+  <Component className={classes.root} {...otherProps}>
+    <div className={classes.message}>
+      <ReleaseTag style={{marginRight: '0.5ex'}}>alpha</ReleaseTag>
+      {' '}This service is in development.{' '} { /* whitespace coalescing in JSX sux! */ }
+      <a className={classes.link} href="/about#help-us">Help us improve it.</a>
+    </div>
+    <Divider />
+  </Component>
+)
+
+MotdBanner.propTypes = {
+  /** Base component for the control. */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+};
+
+MotdBanner.defaultProps = {
+  component: Typography,
+};
+
+const styles = theme => ({
+  root: {
+    marginTop: theme.spacing.unit * 2,
+  },
+
+  message: {
+    paddingBottom: theme.spacing.unit,
+  },
+
+  link: {
+    color: theme.palette.text.secondary,
+  },
+});
+
+export default withStyles(styles)(MotdBanner);

--- a/frontend/src/components/MotdBanner.md
+++ b/frontend/src/components/MotdBanner.md
@@ -1,0 +1,14 @@
+### Examples
+
+```js
+<MotdBanner />
+```
+
+### CSS API
+
+You can override the injected class names with the ``classes`` property. This
+property accepts the following keys:
+
+* ``root``
+* ``message``
+* ``link``

--- a/frontend/src/components/ReleaseTag.js
+++ b/frontend/src/components/ReleaseTag.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { withStyles } from '@material-ui/core/styles';
+
+/**
+ * A tag used to indicate that the webapp is at a particular release stage.
+ *
+ * Any unknown properties supplied will be spread to the root component.
+ */
+const ReleaseTag = ({
+  classes, component: Component, color, children, ...otherProps
+}) => (
+  <Component
+    className={[
+      classes.root,
+      color === 'default' ? classes.colorDefault : null,
+      color === 'primary' ? classes.colorPrimary : null,
+      color === 'secondary' ? classes.colorSecondary : null
+    ].join(' ')}
+    {...otherProps}
+  >
+    { children }
+  </Component>
+)
+
+ReleaseTag.propTypes = {
+  /** The color of the component. */
+  color: PropTypes.oneOf(['default', 'primary', 'secondary', 'inherit']),
+
+  /** Base component for the control. */
+  component: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+};
+
+ReleaseTag.defaultProps = {
+  color: 'default',
+  component: 'span',
+};
+
+const styles = theme => ({
+  root: {
+    borderRadius: theme.spacing.unit * 0.5,
+    display: 'inline-block',
+    padding: [[theme.spacing.unit * 0.5, theme.spacing.unit]],
+    textTransform: 'uppercase',
+  },
+
+  colorDefault: {
+    backgroundColor: theme.palette.getContrastText(theme.palette.background.default),
+    color: theme.palette.background.default,
+  },
+
+  colorPrimary: {
+    backgroundColor: theme.palette.primary.main,
+    color: theme.palette.primary.contrastText,
+  },
+
+  colorSecondary: {
+    backgroundColor: theme.palette.secondary.main,
+    color: theme.palette.secondary.contrastText,
+  },
+});
+
+export default withStyles(styles)(ReleaseTag);

--- a/frontend/src/components/ReleaseTag.md
+++ b/frontend/src/components/ReleaseTag.md
@@ -1,0 +1,27 @@
+### Examples
+
+```js
+Typography = require('@material-ui/core/Typography').default;
+
+<Typography variant="subheading">
+  <ReleaseTag>Alpha</ReleaseTag>
+</Typography>
+```
+
+```js
+Typography = require('@material-ui/core/Typography').default;
+
+<Typography variant="subheading" color="primary">
+  <ReleaseTag color="primary">Alpha</ReleaseTag>
+</Typography>
+```
+
+### CSS API
+
+You can override the injected class names with the ``classes`` property. This
+property accepts the following keys:
+
+* ``root``
+* ``colorPrimary``
+* ``colorSecondary``
+* ``colorDefault``

--- a/frontend/src/pages/IndexPage.js
+++ b/frontend/src/pages/IndexPage.js
@@ -125,6 +125,7 @@ const ProfileButton = withProfile(({ profile, ...otherProps }) => {
 const mediaListSectionStyles = theme => ({
   root: {
     marginBottom: theme.spacing.unit * 4,
+    marginTop: theme.spacing.unit * 2,
   },
 });
 
@@ -166,7 +167,6 @@ const styles = theme => ({
     margin: [[0, 'auto']],
     paddingLeft: theme.spacing.unit * 2,
     paddingRight: theme.spacing.unit * 2,
-    paddingTop: theme.spacing.unit * 3,
 
     [theme.breakpoints.up('sm')]: {
       paddingLeft: theme.spacing.unit * 3,

--- a/frontend/src/pages/IndexPage.js
+++ b/frontend/src/pages/IndexPage.js
@@ -8,6 +8,7 @@ import { withStyles } from '@material-ui/core/styles';
 import { mediaList, mediaResourceToItem } from '../api';
 import AppBar from '../components/AppBar';
 import MediaList from '../components/MediaList';
+import MotdBanner from '../components/MotdBanner';
 import SearchResultsProvider, { withSearchResults } from '../providers/SearchResultsProvider';
 import { withProfile } from '../providers/ProfileProvider';
 import withRoot from './withRoot';
@@ -59,6 +60,8 @@ class IndexPage extends Component {
         </AppBar>
 
         <div className={classes.body}>
+          <MotdBanner />
+
           <SearchResultsProvider query={searchQuery}>
             <SearchResultsSection />
           </SearchResultsProvider>


### PR DESCRIPTION
This PR adds a couple of components to implement an "alpha" banner at the top of the page. Currently the banner links to "/about#help-us" which doesn't exist. Making that page exist is tracked in #90.

Closes #81.