### PR TITLE
Speed up CI and tox runs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,24 +20,39 @@ jobs:
           command: pip install codecov
 
       - run:
+          name: Create mock secrets.env file
+          command: |
+            cp secrets.env.in secrets.env
+
+      - run:
+          name: Test production container health check
+          command: |
+            # Start production containers
+            ./compose.sh production up -d
+
+            # Fetch endpoint
+            ./compose/wait-for-it.sh localhost:8000 -t 15
+            ./compose.sh production exec production_app ./manage.py migrate
+            curl --verbose --location --output /tmp/healthz --fail --connect-timeout 2 http://localhost:8000/healthz
+
+            # Before it goes away, tag the production container
+            IMAGE=$(./compose.sh production images -q production_app)
+            echo "-- Production container image id: $IMAGE"
+            [ -z "${IMAGE}" ] && (echo "could not determined image id" >&2; exit 1)
+            docker tag ${IMAGE} production:latest
+
+            # Stop production containers
+            ./compose.sh production down
+
+      - run:
           name: Run tests
           command: |
             ./compose.sh tox run -v $PWD:/tmp/workspace -e COVERAGE_FILE=/tmp/workspace/.coverage -e TOXINI_ARTEFACT_DIR=/tmp/workspace/build --rm tox
             ./compose.sh tox down
 
       - run:
-          name: Test production container health check
+          name: Tag production container
           command: |
-            cp secrets.env.in secrets.env
-            ./compose.sh production up -d
-            ./compose/wait-for-it.sh localhost:8000 -t 15
-            ./compose.sh production exec production_app ./manage.py migrate
-            curl --verbose --location --output /tmp/healthz --fail --connect-timeout 2 http://localhost:8000/healthz
-
-      - run:
-          name: Build and tag production container
-          command: |
-            docker build -t production .
             docker tag production:latest eu.gcr.io/$GCLOUD_PROJECT/$CIRCLE_PROJECT_REPONAME:sha-$CIRCLE_SHA1
             docker tag production:latest eu.gcr.io/$GCLOUD_PROJECT/$CIRCLE_PROJECT_REPONAME:branch-$CIRCLE_BRANCH
             docker tag production:latest eu.gcr.io/$GCLOUD_PROJECT/$CIRCLE_PROJECT_REPONAME:build-$CIRCLE_BUILD_NUM

--- a/.dockerignore
+++ b/.dockerignore
@@ -20,3 +20,6 @@ coverage.xml
 build
 frontend/node_modules
 frontend/build
+
+# To make sure we don't accidentally publish an image with secrets
+secrets.env

--- a/compose/tox.env
+++ b/compose/tox.env
@@ -1,3 +1,4 @@
 TOXINI_WORK_DIR=/tmp/tox-data/work
 TOXINI_ARTEFACT_DIR=/tmp/tox-data/artefacts
+TOXINI_SITEPACKAGES=True
 COVERAGE_FILE=/tmp/tox-data/coverage

--- a/tox.ini
+++ b/tox.ini
@@ -59,6 +59,10 @@ commands=
     coverage run --source={toxinidir} ./manage.py test {posargs}
     coverage html --directory {[_vars]build_root}/htmlcov/
     coverage report
+# Allow sitepackages setting to be overridden via TOX_SITEPACKAGES environment
+# variable. The tox container uses this to avoid re-installing the same packages
+# over and over again.
+sitepackages={env:TOXINI_SITEPACKAGES:False}
 
 # Build documentation
 [testenv:doc]


### PR DESCRIPTION
This PR tweaks the CircleCI ordering and tox config to improve the speed of CI.

As an example: https://circleci.com/gh/rjw57/sms-webapp/93 completed in 8:44 compared with the last build on master, https://circleci.com/gh/uisautomation/sms-webapp/73, which took 19:51. This is a better than two-times speed up.

See the individual commit messages for the rationale for each change.