### PR TITLE
Fix HTTP->HTTPS redirect

### DIFF
--- a/smswebapp/settings/base.py
+++ b/smswebapp/settings/base.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 #: Base directory containing the project. Build paths inside the project via
 #: ``os.path.join(BASE_DIR, ...)``.
@@ -39,6 +40,7 @@ INSTALLED_APPS = [
 #: Installed middleware
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
+    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'corsheaders.middleware.CorsMiddleware',
@@ -46,7 +48,6 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'smsjwplatform.middleware.user_lookup_middleware'
 ]
 
@@ -212,8 +213,18 @@ CORS_ORIGIN_ALLOW_ALL = True
 STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'
 STATIC_ROOT = os.environ.get('DJANGO_STATIC_ROOT', os.path.join(BASE_DIR, 'build', 'static'))
 
-# See wsgi.py for how this is used.
+# Serve the frontend files from the application root. We use WHITENOISE_INDEX_FILE to make sure
+# that index.html is used for /.
 FRONTEND_APP_BUILD_DIR = os.environ.get(
     'DJANGO_FRONTEND_APP_BUILD_DIR',
     os.path.abspath(os.path.join(BASE_DIR, 'frontend', 'build'))
 )
+
+# If the build directory for the frontend actually exists, serve files for the root of the
+# application from it. Print a warning otherwise.
+if os.path.isdir(FRONTEND_APP_BUILD_DIR):
+    WHITENOISE_ROOT = FRONTEND_APP_BUILD_DIR
+    WHITENOISE_INDEX_FILE = True
+else:
+    print('Warning: FRONTEND_APP_BUILD_DIR does not exist. The frontend will not be served',
+          file=sys.stderr)

--- a/smswebapp/settings/base.py
+++ b/smswebapp/settings/base.py
@@ -228,3 +228,23 @@ if os.path.isdir(FRONTEND_APP_BUILD_DIR):
 else:
     print('Warning: FRONTEND_APP_BUILD_DIR does not exist. The frontend will not be served',
           file=sys.stderr)
+
+# By default we a) redirect all HTTP traffic to HTTPS, b) set the HSTS header to a maximum age
+# of 1 year (as per the consensus recommendation from a quick Google search) and c) advertise that
+# we are willing to be "preloaded" into Chrome and Firefox's internal list of HTTPS-only sites.
+# Set the DANGEROUS_DISABLE_HTTPS_REDIRECT variable to any non-blank value to disable this.
+if os.environ.get('DANGEROUS_DISABLE_HTTPS_REDIRECT', '') == '':
+    # Exempt the healtch-check endpoint from the HTTP->HTTPS redirect.
+    SECURE_REDIRECT_EXEMPT = ['^healthz/?$']
+
+    SECURE_SSL_REDIRECT = True
+    SECURE_HSTS_SECONDS = 31536000  # == 1 year
+    SECURE_HSTS_PRELOAD = True
+else:
+    print('Warning: HTTP to HTTPS redirect has been disabled.', file=sys.stderr)
+
+# We also support the X-Forwarded-Proto header to detect if we're behind a load balancer which does
+# TLS termination for us. In future this setting might need to be moved to settings.docker or to be
+# configured via an environment variable if we want to support a wider range of TLS terminating
+# load balancers.
+SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')

--- a/smswebapp/settings/docker.py
+++ b/smswebapp/settings/docker.py
@@ -11,12 +11,6 @@ SECRET_KEY = os.environ['DJANGO_SECRET_KEY']
 # variable is set and is non-empty.
 DEBUG = os.environ.get('SMS_ENABLE_DEBUG_THIS_IS_DANGEROUS', '') != ''
 
-# Redirect all traffic except healthz endpoint to HTTPS unless DANGEROUS_DISABLE_HTTPS_REDIRECT
-# is set
-SECURE_SSL_REDIRECT = os.environ.get('DANGEROUS_DISABLE_HTTPS_REDIRECT') is None
-SECURE_REDIRECT_EXEMPT = ['^healthz$']
-SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
-
 # Allow all hosts to connect
 ALLOWED_HOSTS = ['*']
 

--- a/smswebapp/wsgi.py
+++ b/smswebapp/wsgi.py
@@ -10,25 +10,7 @@ https://docs.djangoproject.com/en/2.0/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
-from whitenoise import WhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "smswebapp.settings")
 
 application = get_wsgi_application()
-
-# Only *after* the application is initialised above will the Django settings be available.
-from django.conf import settings  # noqa: E402
-
-whitenoise_params = {}
-
-if settings.DEBUG:
-    # In development (when DEBUG is True), enable the whitenoise autorefresh feature which will
-    # check if the file has updated on disk before responding.
-    whitenoise_params['autorefresh'] = True
-
-application = WhiteNoise(
-    application,
-    root=settings.FRONTEND_APP_BUILD_DIR, prefix='/',
-    index_file=True,
-    **whitenoise_params,
-)

--- a/tox.ini
+++ b/tox.ini
@@ -49,6 +49,9 @@ setenv=
     DJANGO_DB_ENGINE={env:DJANGO_DB_ENGINE:django.db.backends.sqlite3}
     DJANGO_DB_NAME={env:DJANGO_DB_NAME:{envtmpdir}/testsuite-db.sqlite3}
     TOX_STATIC_ROOT={[_vars]build_root}/static
+#   Make sure that the HTTP->HTTPS redirect is disabled when running the test
+#   suite.
+    DANGEROUS_DISABLE_HTTPS_REDIRECT=1
 # How to run the test suite. Note that arguments passed to tox are passed on to
 # the test command.
 commands=


### PR DESCRIPTION
Our previous hack for getting whitenoise to serve the root of the application worked too well. Whitenoise served the index.html file before Django had a chance to add the redirect header. Fortunately, the WhitenoiseMiddleware actually supports serving static files from the root of the application by means of the WHITENOISE_ROOT setting. Make use of it to make sure HTTP->HTTPS redirects happen.

Fixing the whitenoise problem exposed some follow on issues to do with testing. Since tox does not pass environment variables to testenv's, the DANGEROUS_DISABLE_HTTP_REDIRECT variable was not being set. Since the redirect was broken, this didn't actually matter. Now it's fixed, we need to set the DANGEROUS_DISABLE_HTTP_REDIRECT variable within the tox testenv.

While we're at the HTTPS configuration, add the HSTS headers to make sure that browsers always visit our page over HTTPS after the first visit.

Closes #96