### PR TITLE
Add legacy sms redirect for media item page

### DIFF
--- a/legacysms/redirect.py
+++ b/legacysms/redirect.py
@@ -41,6 +41,16 @@ def media_download(media_id, clip_id, extension):
         settings.LEGACY_SMS_DOWNLOADS_URL, f'{media_id:d}/{clip_id:d}.{extension}'))
 
 
+def media_page(media_id):
+    """
+    Returns a :py:class:`HttpResponse` which redirects back to the legacy media item page for the
+    given media id. Raises :py:exc:`ValueError` if *media_id* is non-numeric.
+
+    """
+    return _redirect_relative(urlparse.urljoin(
+        settings.LEGACY_SMS_FRONTEND_URL, f'media/{media_id:d}'))
+
+
 def _redirect_relative(url):
     """
     Given a relative URL path, return the redirect to the full URL formed using the

--- a/legacysms/tests/test_redirect.py
+++ b/legacysms/tests/test_redirect.py
@@ -62,3 +62,20 @@ class DownloadTests(TestCase):
         """Passing non-integer clip id raises an error."""
         with self.assertRaises(ValueError):
             redirect.media_download(1234, 'some/malicious/path', 'mp4')
+
+
+@override_settings(
+    LEGACY_SMS_REDIRECT_FORMAT='{url.scheme}://test.{url.netloc}{url.path}',
+    LEGACY_SMS_FRONTEND_URL='https://sms.invalid/'
+)
+class MediaPageTests(TestCase):
+    def test_basic_redirect(self):
+        """A simple redirect should produce the correct result."""
+        self.assertRedirects(
+            redirect.media_page(1234), 'https://test.sms.invalid/media/1234',
+            fetch_redirect_response=False)
+
+    def test_requires_integer(self):
+        """Passing non-integer raises an error."""
+        with self.assertRaises(ValueError):
+            redirect.media_page('some/malicious/path')

--- a/legacysms/urls.py
+++ b/legacysms/urls.py
@@ -17,4 +17,5 @@ urlpatterns = [
     path('rss/media/<int:media_id>/', views.rss_media, name='rss_media'),
     path('downloads/<int:media_id>/<int:clip_id>.<extension>', views.download_media,
          name='download_media'),
+    path('media/<int:media_id>/', views.media, name='media'),
 ]


### PR DESCRIPTION
Add an endpoint under /legacy for handling individual media pages. It maps the SMS media id to a JWPlayer key and redirects to the new media page. If the media item could not be found or if the ACL disallows viewing, the user is redirected back to the original SMS application to let it deal with the problem.

Closes #82