### PR TITLE
move over to using uisautomation images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD ./frontend/ ./
 RUN npm install && npm run build
 
 # Use python alpine image to run webapp proper
-FROM uisautomation/python:django
+FROM uisautomation/django:2.0-py3.6
 
 # Ensure packages are up to date and install some useful utilities
 RUN apk update && apk add git vim postgresql-dev libffi-dev gcc musl-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD ./frontend/ ./
 RUN npm install && npm run build
 
 # Use python alpine image to run webapp proper
-FROM python:3.6-alpine
+FROM uisautomation/python:django
 
 # Ensure packages are up to date and install some useful utilities
 RUN apk update && apk add git vim postgresql-dev libffi-dev gcc musl-dev \

--- a/compose/lookupproxy.Dockerfile
+++ b/compose/lookupproxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM uisautomation/python:django
 
 # Do everything relative to /usr/src/app which is where we install our
 # application.

--- a/compose/lookupproxy.Dockerfile
+++ b/compose/lookupproxy.Dockerfile
@@ -1,4 +1,4 @@
-FROM uisautomation/python:django
+FROM uisautomation/django:2.0-py3.6
 
 # Do everything relative to /usr/src/app which is where we install our
 # application.

--- a/compose/start-devserver.sh
+++ b/compose/start-devserver.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 #
 # Run a database migration and start the development server.
 set -xe


### PR DESCRIPTION
The uisautomation/dockerimages repo has CircleCI configuration to allow nightly builds of python images with updated apk packages and various useful modules pre-installed to appear at https://hub.docker.com/r/uisautomation/.

Change our Dockerfiles over to be based on https://hub.docker.com/r/uisautomation/python/ (the django variant).  This saves us the build time for various tediously long-to-install modules like lxml in our CI builds.

See, e.g., https://circleci.com/gh/rjw57/sms-webapp/117 which has a build time of 4m18.