### PR TITLE
Branding fixes

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -19,7 +19,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>{% block title %}University Media Platform{% endblock %}</title>
+    <title>{% block title %}The University of Cambridge Media Platform{% endblock %}</title>
 
     {% block extra_head %}{% endblock %}
   </head>

--- a/frontend/public/manifest.json
+++ b/frontend/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "University Media Platform",
-  "name": "University Media Platform",
+  "short_name": "The University of Cambridge Media Platform",
+  "name": "The University of Cambridge Media Platform",
   "icons": [
     {
       "src": "favicon.png",

--- a/frontend/src/components/AppBar.js
+++ b/frontend/src/components/AppBar.js
@@ -73,7 +73,7 @@ const AppBar = (
     <Grid container component={Toolbar}>
       <Grid item xs={3} className={classes.appBarLeft}>
         <Typography variant="title" color="inherit">
-          <img src={ShieldImage} alt="University Media Platform" style={{verticalAlign: 'bottom', height: '1.8em'}} />
+          <img src={ShieldImage} alt="The University of Cambridge Media Platform" style={{verticalAlign: 'bottom', height: '1.8em'}} />
         </Typography>
       </Grid>
       <Grid item xs={12} sm={9} md={6} className={classes.appBarMiddle}>

--- a/ui/templates/ui/about.html
+++ b/ui/templates/ui/about.html
@@ -8,7 +8,7 @@
 
     <link rel="shortcut icon" href="/favicon.png">
 
-    <title>About The University Media Platform</title>
+    <title>About The University of Cambridge Media Platform</title>
     <style>
       body {
         background-color: #f3f3f3;
@@ -48,15 +48,16 @@
     <div class="paper">
       <div class="wrapper">
         <div class="frame">
-          <h2>The University Media Platform</h2>
+          <h2>The University of Cambridge Media Platform</h2>
           <p>
-            The University Media Platform (UMP) is a cloud based service which allows University staff to provide
+            The University of Cambridge Media Platform is a cloud based service which allows University staff to provide
             audio and video content to a target audience.
             It is intended as a replacement for the
-            <a target="_blank" href="https://sms.cam.ac.uk/">Streaming Media Service</a> (SMS).
-            The platform is a partially featured prototype and shares the SMS data.
-            So content uploaded to and managed in the SMS can be searched and viewed in the UMP.
-            Additionally, user access set in the SMS is respected by the UMP.
+            <a target="_blank" href="https://sms.cam.ac.uk/">Streaming Media Service</a>.
+            The platform is a partially featured prototype and shares the Streaming Media Service data.
+            So content uploaded to and managed in the Streaming Media Service can be searched and viewed in
+            The Media Platform. Additionally, user access set in the Streaming Media Service is respected by
+            The Media Platform.
           </p>
           <h2>What we mean by an <b>Alpha</b> release</h2>
           <p>
@@ -72,10 +73,10 @@
           </p>
           <h2 id="help-us">How you can give us feedback</h2>
           <p>
-            We'd really appreciate any feedback on the UMP, and the experience you've had so far.
+            We'd really appreciate any feedback on The Media Platform, and the experience you've had so far.
             This could be areas of improvement, future feature requests, or issues that you're having using the product.
           </p><p>
-            The user-experience team can be contacted at: ux@uis.cam.ac.uk
+            The user-experience team can be contacted at: media@uis.cam.ac.uk
           </p>
           <h2>For Developers</h2>
           <p>


### PR DESCRIPTION
Removes all acronyms and replaces them with full name.
Full name is now: The University of Cambridge Media Platform
Short name is now: The Media Platform

Closes #118 