### PR TITLE
use new decoupled lookup API

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,8 @@ WORKDIR /usr/src/app
 # requirements/docker.txt last to allow it to override any versions in
 # requirements/requirements.txt.
 ADD ./requirements/* ./requirements/
-RUN pip install --no-cache-dir -r requirements/base.txt && \
-	pip install --no-cache-dir -r requirements/docker.txt
+RUN pip install --upgrade --no-cache-dir -r requirements/base.txt && \
+	pip install --upgrade --no-cache-dir -r requirements/docker.txt
 
 # Copy the remaining files over
 ADD . .

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -16,7 +16,7 @@ class ViewTestCase(TestCase):
         self.get_request = self.factory.get('/')
         self.user = get_user_model().objects.create_user(username='test0001')
         self.patch_get_jwplatform_client()
-        self.patch_get_person_for_user()
+        self.patch_get_person()
         self.client = self.get_jwplatform_client()
 
     def patch_get_jwplatform_client(self):
@@ -25,14 +25,14 @@ class ViewTestCase(TestCase):
         self.get_jwplatform_client = self.get_jwplatform_client_patcher.start()
         self.addCleanup(self.get_jwplatform_client_patcher.stop)
 
-    def patch_get_person_for_user(self):
-        self.get_person_for_user_patcher = mock.patch('smsjwplatform.acl.get_person_for_user')
-        self.get_person_for_user = self.get_person_for_user_patcher.start()
-        self.get_person_for_user.return_value = {
+    def patch_get_person(self):
+        self.get_person_patcher = mock.patch('automationlookup.get_person')
+        self.get_person = self.get_person_patcher.start()
+        self.get_person.return_value = {
             'institutions': [{'instid': 'UIS'}],
             'groups': [{'groupid': '12345', 'name': 'uis-members'}]
         }
-        self.addCleanup(self.get_person_for_user_patcher.stop)
+        self.addCleanup(self.get_person_patcher.stop)
 
 
 class ProfileViewTestCase(ViewTestCase):

--- a/compose/development.django.Dockerfile
+++ b/compose/development.django.Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get -y update && apt-get -y install postgresql-client
 
 # Install any explicit developer requirements
 ADD ./requirements/* ./requirements/
-RUN pip install -r ./requirements/developer.txt
+RUN pip install --upgrade -r ./requirements/developer.txt
 
 # The webapp source will be mounted here as a volume
 VOLUME /usr/src/app

--- a/smsjwplatform/acl.py
+++ b/smsjwplatform/acl.py
@@ -4,7 +4,9 @@ Module providing functionality for handling ACL's stored in the JWPlayer custom 
 """
 import logging
 
-from automationlookup.lookup import get_person_for_user
+from django.conf import settings
+
+import automationlookup
 
 LOG = logging.getLogger(__name__)
 
@@ -57,7 +59,8 @@ class AceInst:
         if user.is_anonymous:
             return False
 
-        lookup_response = get_person_for_user(user)
+        lookup_response = automationlookup.get_person(
+            user.username, settings.LOOKUP_SCHEME, fetch=['all_insts'])
 
         for institution in lookup_response.get('institutions', []):
             if self.instid == institution.get('instid', None):
@@ -84,7 +87,8 @@ class AceGroup:
         if user.is_anonymous:
             return False
 
-        lookup_response = get_person_for_user(user)
+        lookup_response = automationlookup.get_person(
+            user.username, settings.LOOKUP_SCHEME, fetch=['all_groups'])
 
         for institution in lookup_response.get('groups', []):
             if self.groupid == institution.get('groupid') or \

--- a/smsjwplatform/tests/test_acl.py
+++ b/smsjwplatform/tests/test_acl.py
@@ -75,7 +75,7 @@ class AceInstTest(TestCase):
         self.assertIsNone(AceInst.parse('USER_mb2174'))
 
     def test_has_permission(self):
-        patch_get_person_for_user(self)
+        patch_get_person(self)
         user = mock.Mock(is_anonymous=False)
 
         self.assertTrue(AceInst('UIS').has_permission(user))
@@ -96,7 +96,7 @@ class AceGroupTest(TestCase):
         self.assertIsNone(AceInst.parse('USER_mb2174'))
 
     def test_has_permission(self):
-        patch_get_person_for_user(self)
+        patch_get_person(self)
         user = mock.Mock(is_anonymous=False)
 
         self.assertTrue(AceGroup('12345').has_permission(user))
@@ -123,12 +123,12 @@ class AceUserTest(TestCase):
         self.assertTrue(ace_user.has_permission(mock.Mock(username="mb2174")))
 
 
-def patch_get_person_for_user(self):
-    get_person_for_user = mock.Mock()
-    get_person_for_user.return_value = {
+def patch_get_person(self):
+    get_person = mock.Mock()
+    get_person.return_value = {
         'institutions': [{'instid': 'UIS'}],
         'groups': [{'groupid': '12345', 'name': 'uis-members'}]
     }
-    patcher = mock.patch('smsjwplatform.acl.get_person_for_user', get_person_for_user)
+    patcher = mock.patch('automationlookup.get_person', get_person)
     self.addCleanup(patcher.stop)
     patcher.start()

--- a/smswebapp/settings/base.py
+++ b/smswebapp/settings/base.py
@@ -28,6 +28,7 @@ INSTALLED_APPS = [
 
     'automationcommon',
     'automationlookup',
+    'automationoauth',
     'corsheaders',
     'drf_yasg',
     'rest_framework',
@@ -248,3 +249,5 @@ else:
 # configured via an environment variable if we want to support a wider range of TLS terminating
 # load balancers.
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+
+LOOKUP_SCHEME = 'crsid'

--- a/smswebapp/settings/developer.py
+++ b/smswebapp/settings/developer.py
@@ -46,3 +46,5 @@ STATIC_URL = '/static/'
 
 OAUTH2_TOKEN_URL = 'http://hydra:4444/oauth2/token'
 LOOKUP_ROOT = 'http://lookupproxy:8080/'
+
+LOOKUP_SCHEME = 'mock'


### PR DESCRIPTION
As noted in uisautomation/django-automationoauth#5, the lookup proxy API assumed that the user had been created by the DRF authentication system in that repo and not by any other means.  uisautomation/django-automationoauth#5 provides a de-coupled lookup API which does not use the ``UserLookup`` module. Change our use of get_person_for_user() to the new get_person() method.