### PR TITLE
Convert UI to use MediaItem objects

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -1,9 +1,11 @@
 import logging
+from urllib import parse as urlparse
 
 from django.conf import settings
 from rest_framework import serializers
 
 from smsjwplatform import jwplatform
+from mediaplatform import models as mpmodels
 
 LOG = logging.getLogger(__name__)
 
@@ -19,31 +21,66 @@ class SourceSerializer(serializers.Serializer):
     height = serializers.IntegerField(help_text='The video height', required=False)
 
 
-class MediaSerializer(serializers.Serializer):
+class LegacySMSMediaSerializer(serializers.Serializer):
+    id = serializers.IntegerField(help_text='Unique id for an SMS media')
+    statisticsUrl = serializers.SerializerMethodField(help_text='Link to statistics page')
+
+    def get_statisticsUrl(self, obj):
+        return urlparse.urljoin(
+            settings.LEGACY_SMS_FRONTEND_URL, f'media/{obj.id:d}/statistics')
+
+
+class MediaSerializer(serializers.HyperlinkedModelSerializer):
     """
     An individual media item.
 
+    This schema corresponds to Google's recommended layout for a Video object
+    (https://developers.google.com/search/docs/data-types/video).
+
     """
-    id = serializers.CharField(help_text='Unique id for the media')
-    title = serializers.CharField(help_text='Title of media')
+    class Meta:
+        model = mpmodels.MediaItem
+        fields = (
+            'id', 'name', 'description', 'duration', 'embedUrl', 'thumbnailUrl',
+            'uploadDate', 'legacy', 'key'
+        )
+
+    # In JSON-LD, this should be "@id" but DRF doesn't make it easy to have @ signs in field naes
+    # so we rename this field in to_representation() below.
+    id = serializers.HyperlinkedIdentityField(
+        view_name='api:media_item', help_text='Unique URL for the media')
+    key = serializers.CharField(source='id', help_text='Unique id for media')
+    name = serializers.CharField(source='title', help_text='Title of media')
     description = serializers.CharField(help_text='Description of media')
-    published_at = serializers.DateTimeField(
-        help_text='Publication time')
-    poster_image_url = serializers.SerializerMethodField(
-        help_text='A URL of a thumbnail/poster image for the media'
-    )
-    duration = serializers.FloatField(help_text='Duration of the media in seconds')
-    player_url = serializers.SerializerMethodField(
+    duration = serializers.SerializerMethodField(
+        help_text='Duration of the media in ISO 8601 format')
+    embedUrl = serializers.SerializerMethodField(
         help_text='A URL to retrieve an embeddable player for the media item.'
     )
-    media_id = serializers.SerializerMethodField(help_text='Unique id for an SMS media')
+    thumbnailUrl = serializers.SerializerMethodField(
+        help_text='A URL of a thumbnail/poster image for the media'
+    )
+    uploadDate = serializers.DateTimeField(source='published_at', help_text='Publication time')
+
+    legacy = LegacySMSMediaSerializer(
+        source='sms', help_text='Information from legacy SMS', required=False)
+
+    def get_duration(self, obj):
+        """Return the media item's duration in ISO 8601 format."""
+        if obj.duration is None:
+            return None
+
+        hours, remainder = divmod(obj.duration, 3600)
+        minutes, seconds = divmod(remainder, 60)
+
+        return "PT{:d}H{:02d}M{:02.1f}S".format(int(hours), int(minutes), seconds)
 
     def get_media_id(self, obj):
         if not hasattr(obj, 'sms'):
             return None
         return obj.sms.id
 
-    def get_player_url(self, obj):
+    def get_embedUrl(self, obj):
         if not hasattr(obj, 'jwp'):
             return None
         return jwplatform.player_embed_url(
@@ -51,10 +88,27 @@ class MediaSerializer(serializers.Serializer):
             settings.JWPLATFORM_CONTENT_BASE_URL
         )
 
-    def get_poster_image_url(self, obj):
+    def get_thumbnailUrl(self, obj):
         if not hasattr(obj, 'jwp'):
             return None
-        return jwplatform.Video({'key': obj.jwp.key}).get_poster_url()
+        return [
+            jwplatform.Video({'key': obj.jwp.key}).get_poster_url(width=width)
+            for width in [1280, 640, 320]
+        ]
+
+    def to_representation(self, obj):
+        """
+        Custom to_representation() override which adds JSON-LD fields.
+
+        """
+        data = super().to_representation(obj)
+        data.update({
+            '@id': data['id'],
+            '@context': 'http://schema.org',
+            '@type': 'VideoObject',
+        })
+        del data['id']
+        return data
 
 
 class MediaDetailSerializer(MediaSerializer):
@@ -62,17 +116,38 @@ class MediaDetailSerializer(MediaSerializer):
     Serialize a media object with greater detail for an individual media detail response
 
     """
-    sources = serializers.SerializerMethodField(
-        help_text='A collection of download URLs for different media types.'
-    )
-
     def get_sources(self, obj):
-        if not hasattr(obj, 'jwp'):
+        if not obj.downloadable or not hasattr(obj, 'jwp'):
             return None
 
         video = jwplatform.DeliveryVideo.from_key(obj.jwp.key)
 
         return SourceSerializer(video.get('sources'), many=True).data
+
+    def to_representation(self, obj):
+        """
+        Custom to_representation() subclass which examines the sources to set the "best" source
+        in contentUrl.
+
+        """
+        data = super().to_representation(obj)
+        sources = self.get_sources(obj)
+
+        if sources is not None and len(sources) > 0:
+            audio_sources = [s for s in sources if s.get('mime_type') == 'audio/mp4']
+            video_sources = sorted(
+                (
+                    s for s in sources
+                    if s.get('mime_type') == 'video/mp4' and s.get('height') is not None
+                ),
+                key=lambda s: s.get('height'), reverse=True)
+
+            if len(video_sources) > 0:
+                data['contentUrl'] = video_sources[0].get('url')
+            elif len(audio_sources) > 0:
+                data['contentUrl'] = audio_sources[0].get('url')
+
+        return data
 
 
 class CollectionSerializer(serializers.Serializer):

--- a/api/tests/fixtures/mediaitems.yaml
+++ b/api/tests/fixtures/mediaitems.yaml
@@ -1,0 +1,54 @@
+# Test media item fixtures
+- model: mediaplatform.MediaItem
+  pk: a
+  fields:
+    title: item a, xxx
+    description: description of item a, yyy
+    tags:
+      - aaa
+      - bbb
+      - ccc
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform.MediaItem
+  pk: empty
+  fields:
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform.MediaItem
+  pk: deleted
+  fields:
+    deleted_at: 2011-09-15 12:00:00
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform.MediaItem
+  pk: populated
+  fields:
+    title: a fully populated item
+    description: description of daid
+    duration: 34
+    type: video
+    published_at: 2010-09-15 14:40:45
+    downloadable: true
+    language: eng
+    copyright: foo
+    tags:
+      - tag1
+      - tag2
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform_jwp.Video
+  pk: jwpvid1
+  fields:
+    updated: 12345
+    item: populated
+
+- model: legacysms.MediaItem
+  pk: 1234
+  fields:
+    last_updated_at: 2010-09-15 14:40:45
+    item: populated

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -125,7 +125,7 @@ class MediaListViewTestCase(ViewTestCase):
 
         expected_ids = set(o.id for o in self.viewable_by_anon)
         for item in response_data['results']:
-            self.assertIn(item['id'], expected_ids)
+            self.assertIn(item['key'], expected_ids)
 
     def test_auth_list(self):
         """An authenticated user should get expected media back."""
@@ -138,7 +138,7 @@ class MediaListViewTestCase(ViewTestCase):
 
         expected_ids = set(o.id for o in self.viewable_by_user)
         for item in response_data['results']:
-            self.assertIn(item['id'], expected_ids)
+            self.assertIn(item['key'], expected_ids)
 
 
 class MediaViewTestCase(ViewTestCase):
@@ -158,17 +158,17 @@ class MediaViewTestCase(ViewTestCase):
 
         mock_from_id.assert_called_with(item.jwp.key)
 
-        self.assertEqual(response.data['id'], item.id)
-        self.assertEqual(response.data['title'], item.title)
+        self.assertEqual(response.data['key'], item.id)
+        self.assertEqual(response.data['name'], item.title)
         self.assertEqual(response.data['description'], item.description)
-        self.assertEqual(dateparser.parse(response.data['published_at']), item.published_at)
-        self.assertEqual(
-            response.data['poster_image_url'],
-            'https://cdn.jwplayer.com/thumbs/{}-720.jpg'.format(item.jwp.key)
+        self.assertEqual(dateparser.parse(response.data['uploadDate']), item.published_at)
+        self.assertIn(
+            'https://cdn.jwplayer.com/thumbs/{}-1280.jpg'.format(item.jwp.key),
+            response.data['thumbnailUrl']
         )
-        self.assertEqual(response.data['duration'], item.duration)
-        self.assertEqual(response.data['media_id'], item.sms.id)
-        self.assertTrue(response.data['player_url'].startswith(
+        self.assertIsNotNone(response.data['duration'])
+        self.assertEqual(response.data['legacy']['id'], item.sms.id)
+        self.assertTrue(response.data['embedUrl'].startswith(
             'https://content.jwplatform.com/players/{}-someplayer.html'.format(item.jwp.key)
         ))
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -1,23 +1,31 @@
 from unittest import mock
 
+from dateutil import parser as dateparser
 from django.contrib.auth import get_user_model
+from django.contrib.auth.models import AnonymousUser
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory, force_authenticate
 
 import smsjwplatform.jwplatform as api
-from smsjwplatform.models import CachedResource
+import mediaplatform.models as mpmodels
 
 from .. import views
 
 
 class ViewTestCase(TestCase):
+    fixtures = ['api/tests/fixtures/mediaitems.yaml']
+
     def setUp(self):
         self.factory = APIRequestFactory()
         self.get_request = self.factory.get('/')
         self.user = get_user_model().objects.create_user(username='test0001')
         self.patch_get_jwplatform_client()
         self.patch_get_person()
-        self.client = self.get_jwplatform_client()
+        self.jwp_client = self.get_jwplatform_client()
+        self.non_deleted_media = mpmodels.MediaItem.objects.all()
+        self.media_including_deleted = mpmodels.MediaItem.objects_including_deleted.all()
+        self.viewable_by_anon = self.non_deleted_media.viewable_by_user(AnonymousUser())
+        self.viewable_by_user = self.non_deleted_media.viewable_by_user(self.user)
 
     def patch_get_jwplatform_client(self):
         self.get_jwplatform_client_patcher = mock.patch(
@@ -62,7 +70,7 @@ class CollectionListViewTestCase(ViewTestCase):
     def setUp(self):
         super().setUp()
         self.view = views.CollectionListView().as_view()
-        self.client.channels.list.return_value = {
+        self.jwp_client.channels.list.return_value = {
             'status': 'ok',
             'channels': CHANNELS_FIXTURE,
             'limit': 10,
@@ -89,14 +97,14 @@ class CollectionListViewTestCase(ViewTestCase):
 
     def test_jwplatform_error(self):
         """A JWPlatform error should be reported as a bad gateway error."""
-        self.client.channels.list.return_value = {'status': 'error'}
+        self.jwp_client.channels.list.return_value = {'status': 'error'}
         response = self.view(self.get_request)
         self.assertEqual(response.status_code, 502)
 
     def test_search(self):
         """A search options should be passed through to the API call."""
         self.view(self.factory.get('/?search=foo'))
-        call_args = self.client.channels.list.call_args
+        call_args = self.jwp_client.channels.list.call_args
         self.assertIsNotNone(call_args)
         self.assertIn('search', call_args[1])
         self.assertEqual(call_args[1]['search'], 'foo')
@@ -106,42 +114,34 @@ class MediaListViewTestCase(ViewTestCase):
     def setUp(self):
         super().setUp()
         self.view = views.MediaListView().as_view()
-        for video in VIDEOS_FIXTURE:
-            CachedResource.objects.create(type=CachedResource.VIDEO, key=video['key'], data=video)
 
     def test_basic_list(self):
-        """An user should get all SMS media back."""
+        """An anonymous user should get expected media back."""
         response_data = self.view(self.get_request).data
         self.assertIn('results', response_data)
 
-        # We have some results
         self.assertNotEqual(len(response_data['results']), 0)
+        self.assertEqual(len(response_data['results']), self.viewable_by_anon.count())
 
-        # How many results do we expect
-        visible_videos = [
-            v for v in VIDEOS_FIXTURE if (
-                v.get('custom', {}).get('sms_media_id') is not None
-                and 'WORLD' in v.get('custom', {}).get('sms_acl', '')
-            )
-        ]
-
-        # How many do we get
-        self.assertEqual(len(response_data['results']), len(visible_videos))
+        expected_ids = set(o.id for o in self.viewable_by_anon)
+        for item in response_data['results']:
+            self.assertIn(item['id'], expected_ids)
 
     def test_auth_list(self):
-        """An authenticated user should get more SMS media back."""
-        unauth_response_data = self.view(self.get_request).data
-
+        """An authenticated user should get expected media back."""
         force_authenticate(self.get_request, user=self.user)
-        auth_response_data = self.view(self.get_request).data
+        response_data = self.view(self.get_request).data
+        self.assertIn('results', response_data)
 
-        # Authorised users have more results
-        self.assertGreater(
-            len(auth_response_data['results']), len(unauth_response_data['results']))
+        self.assertNotEqual(len(response_data['results']), 0)
+        self.assertEqual(len(response_data['results']), self.viewable_by_user.count())
+
+        expected_ids = set(o.id for o in self.viewable_by_user)
+        for item in response_data['results']:
+            self.assertIn(item['id'], expected_ids)
 
 
 class MediaViewTestCase(ViewTestCase):
-
     def setUp(self):
         super().setUp()
         self.view = views.MediaView().as_view()
@@ -150,48 +150,40 @@ class MediaViewTestCase(ViewTestCase):
     def test_success(self, mock_from_id):
         """Check that a media item is successfully returned"""
         mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
+        item = self.non_deleted_media.get(id='populated')
 
         # test
-        response = self.view(self.get_request, 'XYZ123')
-
-        mock_from_id.assert_called_with('XYZ123')
-
+        response = self.view(self.get_request, pk=item.id)
         self.assertEqual(response.status_code, 200)
 
-        self.assertEqual(response.data['id'], 'mock1')
-        self.assertEqual(response.data['title'], 'Mock 1')
-        self.assertEqual(response.data['description'], 'Description for mock 1')
-        self.assertEqual(response.data['published_at_timestamp'], 1234567)
+        mock_from_id.assert_called_with(item.jwp.key)
+
+        self.assertEqual(response.data['id'], item.id)
+        self.assertEqual(response.data['title'], item.title)
+        self.assertEqual(response.data['description'], item.description)
+        self.assertEqual(dateparser.parse(response.data['published_at']), item.published_at)
         self.assertEqual(
-            response.data['poster_image_url'], 'https://cdn.jwplayer.com/thumbs/mock1-720.jpg'
+            response.data['poster_image_url'],
+            'https://cdn.jwplayer.com/thumbs/{}-720.jpg'.format(item.jwp.key)
         )
-        self.assertEqual(response.data['duration'], 54.0)
-        self.assertEqual(response.data['media_id'], '1234')
+        self.assertEqual(response.data['duration'], item.duration)
+        self.assertEqual(response.data['media_id'], item.sms.id)
         self.assertTrue(response.data['player_url'].startswith(
-            'https://content.jwplatform.com/players/mock1-someplayer.html'
+            'https://content.jwplatform.com/players/{}-someplayer.html'.format(item.jwp.key)
         ))
 
-    @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
-    def test_video_not_found(self, mock_from_id):
-        """Check that a 404 is returned if not media is found"""
-        mock_from_id.side_effect = api.VideoNotFoundError
-
-        # test
-        response = self.view(self.get_request, 'XYZ123')
-
+    def test_video_not_found(self):
+        """Check that a 404 is returned if no media is found"""
+        response = self.view(self.get_request, pk='this-media-id-does-not-exist')
         self.assertEqual(response.status_code, 404)
 
-    @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
-    def test_no_access_to_video(self, mock_from_id):
-        """Check that a 403 is returned the caller isn't the ACL"""
-        mock_from_id.return_value = api.DeliveryVideo(
-            {**DELIVERY_VIDEO_FIXTURE, 'sms_acl': 'acl:CAM:'}
-        )
+    def test_deleted_video_not_found(self):
+        """Check that a 404 is returned if a deleted media item is asked for."""
+        deleted_item = self.media_including_deleted.filter(deleted_at__isnull=False).first()
+        response = self.view(self.get_request, pk=deleted_item.id)
+        self.assertEqual(response.status_code, 404)
 
-        # test
-        response = self.view(self.get_request, 'XYZ123')
-
-        self.assertEqual(response.status_code, 403)
+    # TODO: implement ACL tests
 
 
 CHANNELS_FIXTURE = [
@@ -228,60 +220,3 @@ DELIVERY_VIDEO_FIXTURE = {
     'sms_acl': 'acl:WORLD:',
     'sms_media_id': 'media:1234:',
 }
-
-
-VIDEOS_FIXTURE = [
-    {
-        'key': 'mock1',
-        'title': 'Mock 1',
-        'description': 'Description for mock 1',
-        'date': 1234567,
-        'duration': 54,
-        'custom': {
-            'sms_media_id': 'media:1234:',
-            'sms_acl': 'acl:WORLD:',
-        },
-    },
-    {
-        'key': 'mock2',
-        'title': 'Mock 2',
-        'description': 'Description for mock 2',
-        'date': 1234567,
-        'duration': 54,
-        'custom': {
-            'sms_media_id': 'media:1235:',
-            'sms_acl': 'acl:WORLD:',
-        },
-    },
-    # See uisautomation/sms2jwplayer#30. There is a video with an odd ACL.
-    {
-        'key': 'oddacl',
-        'title': 'Mock 2',
-        'description': 'Description for mock 2',
-        'date': 1234567,
-        'duration': 54,
-        'custom': {
-            'sms_media_id': 'media:1235:',
-            'sms_acl': "acl:['']:",
-        },
-    },
-    {
-        'key': 'mock3',
-        'title': 'Mock 3',
-        'description': 'Not a SMS collection',
-        'date': 1234567,
-        'duration': 54,
-        'custom': {},
-    },
-    {
-        'key': 'mock4',
-        'title': 'Mock 4',
-        'description': 'Description for mock 4',
-        'date': 1234567,
-        'duration': 54,
-        'custom': {
-            'sms_media_id': 'media:1435:',
-            'sms_acl': 'acl:CAM:',
-        },
-    },
-]

--- a/api/urls.py
+++ b/api/urls.py
@@ -27,7 +27,7 @@ schema_view = get_schema_view(
 urlpatterns = [
     path('collections/', views.CollectionListView.as_view(), name='collections'),
     path('media/', views.MediaListView.as_view(), name='media_list'),
-    path('media/<media_key>', views.MediaView.as_view(), name='media_item'),
+    path('media/<pk>', views.MediaView.as_view(), name='media_item'),
     path('profile/', views.ProfileView.as_view(), name='profile'),
     re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -54,6 +54,6 @@
       try {document.addEventListener("DOMContentLoaded", $buo_f,false)}
       catch(e){window.attachEvent("onload", $buo_f)}
     </script>
-    <script>{% block custom_script %}{% endblock %}</script>
+    {% block extrabody %}{% endblock %}
   </body>
 </html>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -85,8 +85,7 @@ export interface ICollectionListResponse {
 /** A query to the media list endpoint. */
 export interface IMediaQuery {
   search?: string;
-  order_by?: string;
-  direction?: string;
+  ordering?: string;
 };
 
 /** A query to the collection list endpoint. */
@@ -154,16 +153,16 @@ export const apiFetch = (
 
 /** List media resources. */
 export const mediaList = (
-  { search }: IMediaQuery = {}
+  { search, ordering }: IMediaQuery = {}
 ): Promise<IMediaListResponse | IError> => {
-  return apiFetch(API_ENDPOINTS.mediaList + objectToQueryPart({ search }));
+  return apiFetch(API_ENDPOINTS.mediaList + objectToQueryPart({ search, ordering }));
 };
 
 /** List collection resources. */
 export const collectionList = (
-  { search }: IMediaQuery = {}
+  { search, ordering }: IMediaQuery = {}
 ): Promise<ICollectionListResponse | IError> => {
-  return apiFetch(API_ENDPOINTS.collectionList + objectToQueryPart({ search }));
+  return apiFetch(API_ENDPOINTS.collectionList + objectToQueryPart({ search, ordering }));
 };
 
 /** Fetch the user's profile. */

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -44,17 +44,25 @@ export interface ISource {
   height?: number;
 }
 
+export interface ILegacyMedia {
+  id: number;
+  statisticsUrl: string;
+}
+
 /** A media resource. */
 export interface IMediaResource {
-  id: string;
-  title: string;
+  key: string;
+  name: string;
   description: string;
-  published_at_timestamp: number;
-  poster_image_url?: string;
-  duration: number;
-  player_url: string;
-  source?: ISource[];
-  media_id: number;
+  duration: string;
+  embedUrl: string;
+  thumbnailUrl: string[];
+  uploadDate: string;
+  legacy?: ILegacyMedia;
+  '@id': string;
+  '@context': string;
+  '@type': string;
+  contentUrl?: string;
 };
 
 /** A collection resource. */
@@ -199,10 +207,10 @@ export const collectionResourceToItem = (
  * A function which maps an API media resource to a media item for use by, e.g., MediaItemCard.
  */
 export const mediaResourceToItem = (
-  { id, title, description, poster_image_url }: IMediaResource
+  { key, name, description, thumbnailUrl }: IMediaResource
 ) => ({
   description,
-  imageUrl: poster_image_url,
-  title,
-  url: '/media/' + id,
+  imageUrl: thumbnailUrl ? thumbnailUrl[0] : null,
+  title: name,
+  url: '/media/' + key,
 });

--- a/frontend/src/pages/IndexPage.js
+++ b/frontend/src/pages/IndexPage.js
@@ -39,7 +39,7 @@ class IndexPage extends Component {
   componentWillMount() {
     // As soon as the index page mounts, fetch the latest media.
     this.setState({ latestMediaLoading: true });
-    mediaList({ orderBy: 'date', direction: 'desc' }).then(
+    mediaList({ ordering: '-published_at' }).then(
       response => this.setState({ latestMediaResponse: response, latestMediaLoading: false }),
       error => this.setState({ latestMediaResponse: null, latestMediaLoading: false })
     );

--- a/frontend/src/pages/MediaPage.js
+++ b/frontend/src/pages/MediaPage.js
@@ -17,27 +17,39 @@ const MediaPage = ({ mediaItem, classes }) => (
     <section>
       <Grid container spacing={16} className={ classes.gridContainer }>
         <Grid item xs={12} className={ classes.playerWrapper } style={{paddingBottom:'56.25%'}}>
-          <iframe src={mediaItem.player_url} className={ classes.player } width="100%" height="100%" frameBorder="0" allowFullScreen>
+          <iframe src={mediaItem.embedUrl} className={ classes.player } width="100%" height="100%" frameBorder="0" allowFullScreen>
           </iframe>
         </Grid>
         <Grid item xs={12}>
-          <Typography variant="headline" component="div">{ mediaItem.title }</Typography>
+          <Typography variant="headline" component="div">{ mediaItem.name }</Typography>
         </Grid>
         <Grid item xs={12}>
           <RenderedMarkdown source={ mediaItem.description }/>
         </Grid>
         <Grid item xs={6}>
           <Typography variant="subheading">
-            <a target='_blank' className={ classes.link } href={mediaItem.bestSource.url} download>
-              Download media
-            </a>
+            {
+              mediaItem.contentUrl
+              ?
+              <a target='_blank' className={ classes.link } href={mediaItem.contentUrl} download>
+                Download media
+              </a>
+              :
+              null
+            }
           </Typography>
         </Grid>
         <Grid item xs={6} style={{textAlign: 'right'}}>
           <Typography variant="subheading">
-            <a className={ classes.link } href={mediaItem.statsUrl}>
-              Statistics
-            </a>
+            {
+              mediaItem.legacy.statisticsUrl
+              ?
+              <a className={ classes.link } href={mediaItem.legacy.statisticsUrl}>
+                Statistics
+              </a>
+              :
+              null
+            }
           </Typography>
         </Grid>
       </Grid>
@@ -51,38 +63,14 @@ MediaPage.propTypes = {
 
 /**
  * A higher-order component wrapper which passes the media item to its child. At the moment the media
- * item is simply resolved from global data. The wrapper also en-riches the item by:
- *
- *  - selecting the best download source to use.
- *  - creating a link to the legacy statistics page
+ * item is the JSON-parsed contents of an element with id "mediaItem".
  */
 const withMediaItem = WrappedComponent => props => {
-
-  const mediaItem = window.mediaItem;
-
-  // select the best download source to use.
-
-  mediaItem.bestSource = null;
-
-  for (let i = 0; i < mediaItem.sources.length; i++) {
-
-    if (!mediaItem.bestSource) {
-      mediaItem.bestSource = mediaItem.sources[i];
-    }
-
-    if (mediaItem.sources[i].mime_type === "video/mp4") {
-      if (mediaItem.bestSource.mime_type !== mediaItem.sources[i].mime_type) {
-        mediaItem.bestSource = mediaItem.sources[i];
-      }
-      if (mediaItem.bestSource.height < mediaItem.sources[i].height) {
-        mediaItem.bestSource = mediaItem.sources[i];
-      }
-    }
+  let mediaItem = null;
+  const mediaItemElement = document.getElementById('mediaItem');
+  if(mediaItemElement) {
+    mediaItem = JSON.parse(mediaItemElement.textContent);
   }
-
-  // create a link to the legacy statistics page
-
-  mediaItem.statsUrl = BASE_SMS_URL + '/media/' + mediaItem.media_id + '/statistics';
 
   return (<WrappedComponent mediaItem={mediaItem} {...props} />);
 };

--- a/legacysms/tests/test_views.py
+++ b/legacysms/tests/test_views.py
@@ -347,7 +347,7 @@ class MediaPageTest(TestCaseWithFixtures):
 
         """
         r = self.client.get(reverse('legacysms:media', kwargs={'media_id': 34}))
-        self.assertRedirects(r, reverse('ui:media_item', kwargs={'media_key': 'myvideokey'}),
+        self.assertRedirects(r, reverse('ui:media_item', kwargs={'pk': 'myvideokey'}),
                              fetch_redirect_response=False)
 
     def test_no_permission(self):

--- a/legacysms/views.py
+++ b/legacysms/views.py
@@ -210,4 +210,4 @@ def media(request, media_id):
     except api.ResourceACLPermissionDenied:
         return legacyredirect.media_page(media_id)
 
-    return redirect(reverse('ui:media_item', kwargs={'media_key': video.key}))
+    return redirect(reverse('ui:media_item', kwargs={'pk': video.key}))

--- a/mediaplatform/admin.py
+++ b/mediaplatform/admin.py
@@ -159,9 +159,8 @@ class MediaItemAdmin(admin.ModelAdmin):
 
     def get_queryset(self, request):
         """Ensure that related items are also fetched by the queryset."""
-        qs = super().get_queryset(request)
         return (
-            qs
+            models.MediaItem.objects_including_deleted
             .select_related('jwp')
             .select_related('sms')
             .select_related('view_permission')

--- a/mediaplatform/tests/fixtures/test_data.yaml
+++ b/mediaplatform/tests/fixtures/test_data.yaml
@@ -1,0 +1,13 @@
+# Test media items
+- model: mediaplatform.MediaItem
+  pk: empty
+  fields:
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45
+
+- model: mediaplatform.MediaItem
+  pk: deleted
+  fields:
+    deleted_at: 2011-09-15 12:00:00
+    created_at: 2010-09-15 14:40:45
+    updated_at: 2010-09-15 14:40:45

--- a/mediaplatform/tests/test_models.py
+++ b/mediaplatform/tests/test_models.py
@@ -4,9 +4,20 @@ from .. import models
 
 
 class MediaItemTest(TestCase):
+    fixtures = ['mediaplatform/tests/fixtures/test_data.yaml']
+
     def test_creation(self):
         """A MediaItem object should be creatable with no field values."""
         models.MediaItem.objects.create()
+
+    def test_no_deleted_in_objects(self):
+        """The default queryset used by MediaItem.objects contains no deleted items."""
+        self.assertEqual(models.MediaItem.objects.filter(deleted_at__isnull=False).count(), 0)
+
+    def test_deleted_in_objects_including_deleted(self):
+        """If we explicitly ask for deleted objects, we get them."""
+        self.assertGreater(
+            models.MediaItem.objects_including_deleted.filter(deleted_at__isnull=False).count(), 0)
 
 
 class CollectionTest(TestCase):

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -8,3 +8,6 @@ django-debug-toolbar
 
 # Testing
 tox
+
+# For loading test fixtures
+PyYAML

--- a/ui/templates/ui/media.html
+++ b/ui/templates/ui/media.html
@@ -1,5 +1,8 @@
 {% extends 'index.html' %}
 {% block title %}{{title}}{% endblock %}
-{% block custom_script %}
-  window.mediaItem = {% autoescape off %}{{ media_item_json }}{% endautoescape %};
+{% block page_name %}media{% endblock %}
+{% block extrabody %}
+<script id="mediaItem" type="application/ld+json">
+{% autoescape off %}{{ media_item_json }}{% endautoescape %}
+</script>
 {% endblock %}

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -24,11 +24,11 @@ class ViewsTestCase(ViewTestCase):
 
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/media.html')
-        self.assertEqual(r.context['title'], item.title)
+        self.assertEqual(r.context['name'], item.title)
         media_item_json = json.loads(r.context['media_item_json'])
-        self.assertEqual(
-            media_item_json['poster_image_url'],
-            'https://cdn.jwplayer.com/thumbs/{}-720.jpg'.format(item.jwp.key)
+        self.assertIn(
+            'https://cdn.jwplayer.com/thumbs/{}-1280.jpg'.format(item.jwp.key),
+            media_item_json['thumbnailUrl'],
         )
 
     @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -5,30 +5,30 @@ Tests for views.
 import json
 from unittest import mock
 
-from django.test import TestCase
-
 from django.urls import reverse
 
 import smsjwplatform.jwplatform as api
-from api.tests.test_views import DELIVERY_VIDEO_FIXTURE
+from api.tests.test_views import ViewTestCase, DELIVERY_VIDEO_FIXTURE
 
 
-class ViewsTestCase(TestCase):
+class ViewsTestCase(ViewTestCase):
 
     @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
     def test_success(self, mock_from_id):
         """checks that a media item is rendered successfully"""
         mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
+        item = self.non_deleted_media.get(id='populated')
 
         # test
-        r = self.client.get(reverse('ui:media_item', kwargs={'media_key': 'XYZ123'}))
+        r = self.client.get(reverse('ui:media_item', kwargs={'pk': item.pk}))
 
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/media.html')
-        self.assertEqual(r.context['title'], 'Mock 1')
+        self.assertEqual(r.context['title'], item.title)
         media_item_json = json.loads(r.context['media_item_json'])
         self.assertEqual(
-            media_item_json['poster_image_url'], 'https://cdn.jwplayer.com/thumbs/mock1-720.jpg'
+            media_item_json['poster_image_url'],
+            'https://cdn.jwplayer.com/thumbs/{}-720.jpg'.format(item.jwp.key)
         )
 
     @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
@@ -37,18 +37,8 @@ class ViewsTestCase(TestCase):
         mock_from_id.side_effect = api.VideoNotFoundError
 
         # test
-        r = self.client.get(reverse('ui:media_item', kwargs={'media_key': 'XYZ123'}))
+        r = self.client.get(reverse('ui:media_item', kwargs={'pk': 'this-does-not-exist'}))
 
         self.assertEqual(r.status_code, 404)
 
-    @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
-    def test_no_access_to_video(self, mock_from_id):
-        """Check that a 403 is returned the caller isn't the ACL"""
-        mock_from_id.return_value = api.DeliveryVideo(
-            {**DELIVERY_VIDEO_FIXTURE, 'sms_acl': 'acl:CAM:'}
-        )
-
-        # test
-        r = self.client.get(reverse('ui:media_item', kwargs={'media_key': 'XYZ123'}))
-
-        self.assertEqual(r.status_code, 403)
+    # TODO: add ACL checks here

--- a/ui/urls.py
+++ b/ui/urls.py
@@ -21,7 +21,7 @@ from . import views
 app_name = 'ui'
 
 urlpatterns = [
-    path('media/<media_key>', views.MediaView.as_view(), name='media_item'),
+    path('media/<pk>', views.MediaView.as_view(), name='media_item'),
     path('about', TemplateView.as_view(template_name="ui/about.html"), name='about'),
     path('', TemplateView.as_view(template_name="index.html"), name='home'),
 ]

--- a/ui/views.py
+++ b/ui/views.py
@@ -19,8 +19,7 @@ class MediaView(api.views.MediaView):
 
     template_name = 'ui/media.html'
 
-    def get(self, request, media_key):
-
-        response = super().get(request, media_key)
+    def get(self, request, pk):
+        response = super().get(request, pk)
         response.data['media_item_json'] = json.dumps(response.data)
         return response


### PR DESCRIPTION
> PR #142 should be merged before this one is as this PR has the changes from #142 merged.

This PR replaces the media item views and underlying API views to use MediaItem as the source of truth rather than CachedResource. The actual amount of code change is quite small but these commits are rather large because the test suite needed to be fixed up to create MediaItem fixtures as opposed to CachedResource fixtures.

Commit 19b0202 does most of the work on the database model which is required by adding a custom manager and custom query set implementation which makes it hard to accidentally include deleted videos if you don't intend to and to provide a central location to add the database ACL queries. This commit intentionally does not add any ACL checking into this function since that is part of a separate story this sprint. Instead, various TODOs are left where ACL support should be added.

Commit 9e6d3fa a small frontend bug.

Commit c35be11 updates the UI and API views to use MediaItem objects when rendering their response. Moving to using database models means we can make use of DRF's ModelSerializer and DRF's built in ordering and pagination classes. We implement a custom search filter to allow searching by tag/keyword.

Commit d5b6118 experiments with changing the schema of the JSON returned form the API to match the JSON-LD schema for a "Video" object. (Taken from Google's documentation for said.) Again, there's not much code in that commit but a fair amount of churn because all the tests need fixing up.

Closes #126 