### PR TITLE
Re-work API/UI interaction

### DIFF
--- a/api/permissions.py
+++ b/api/permissions.py
@@ -1,0 +1,56 @@
+from rest_framework import permissions
+
+import mediaplatform.models as mpmodels
+
+
+class MediaItemPermission(permissions.BasePermission):
+    """
+    A permission which allows a user access to "safe" HTTP methods if they have the view permission
+    and *additionally* requires the edit permission for "unsafe" HTTP methods.
+
+    The "additional" above implies that a user cannot modify a video if they cannot view it even if
+    they have the edit permission.
+
+    Come what may, a user can do *nothing* to a deleted video.
+
+    """
+    def has_permission(self, request, view):
+        if request.method in permissions.SAFE_METHODS:
+            return True
+
+        # Only signed in users have permissions to perform "unsafe" operations
+        if request.user is None or request.user.is_anonymous:
+            return False
+
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        return self.has_media_item_permission(
+            request, obj, requires_view=True,
+            requires_edit=request.method not in permissions.SAFE_METHODS)
+
+    def has_media_item_permission(self, request, obj, requires_view, requires_edit):
+        # Sanity check that the passed object is a MediaItem.
+        assert isinstance(obj, mpmodels.MediaItem)
+
+        # Ask the DB what the user can do with this item.
+        item = (
+            mpmodels.MediaItem.objects.all()
+            .only()  # Don't fetch all fields; we only use the viewable and editable annotations
+            .annotate_viewable(request.user)
+            .annotate_editable(request.user)
+            .get(id=obj.id)
+        )
+
+        return (not requires_view or item.viewable) and (not requires_edit or item.editable)
+
+
+class MediaItemEditPermission(MediaItemPermission):
+    """
+    Like :py:class:`~.MediaItemPermission` except that the edit permission must *always* be
+    present.
+
+    """
+    def has_object_permission(self, request, view, obj):
+        return self.has_media_item_permission(
+            request, obj, requires_view=True, requires_edit=True)

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -48,22 +48,29 @@ class MediaSerializer(serializers.HyperlinkedModelSerializer):
     # In JSON-LD, this should be "@id" but DRF doesn't make it easy to have @ signs in field naes
     # so we rename this field in to_representation() below.
     id = serializers.HyperlinkedIdentityField(
-        view_name='api:media_item', help_text='Unique URL for the media')
-    key = serializers.CharField(source='id', help_text='Unique id for media')
+        view_name='api:media_item', help_text='Unique URL for the media', read_only=True)
+
+    key = serializers.CharField(source='id', help_text='Unique id for media', read_only=True)
+
     name = serializers.CharField(source='title', help_text='Title of media')
-    description = serializers.CharField(help_text='Description of media')
+
+    description = serializers.CharField(help_text='Description of media', required=False)
+
     duration = serializers.SerializerMethodField(
-        help_text='Duration of the media in ISO 8601 format')
+        help_text='Duration of the media in ISO 8601 format', read_only=True)
+
     embedUrl = serializers.SerializerMethodField(
-        help_text='A URL to retrieve an embeddable player for the media item.'
-    )
+        help_text='A URL to retrieve an embeddable player for the media item.',
+        read_only=True)
+
     thumbnailUrl = serializers.SerializerMethodField(
-        help_text='A URL of a thumbnail/poster image for the media'
-    )
-    uploadDate = serializers.DateTimeField(source='published_at', help_text='Publication time')
+        help_text='A URL of a thumbnail/poster image for the media', read_only=True)
+
+    uploadDate = serializers.DateTimeField(
+        source='published_at', help_text='Publication time', read_only=True)
 
     legacy = LegacySMSMediaSerializer(
-        source='sms', help_text='Information from legacy SMS', required=False)
+        source='sms', help_text='Information from legacy SMS', required=False, read_only=True)
 
     def get_duration(self, obj):
         """Return the media item's duration in ISO 8601 format."""

--- a/api/serializers.py
+++ b/api/serializers.py
@@ -15,7 +15,7 @@ class SourceSerializer(serializers.Serializer):
     A download source for a particular media type.
 
     """
-    mime_type = serializers.CharField(source='type', help_text="The resource's MIME type")
+    mimeType = serializers.CharField(source='type', help_text="The resource's MIME type")
     url = serializers.URLField(source='file', help_text="The resource's URL")
     width = serializers.IntegerField(help_text='The video width', required=False)
     height = serializers.IntegerField(help_text='The video height', required=False)
@@ -30,7 +30,7 @@ class LegacySMSMediaSerializer(serializers.Serializer):
             settings.LEGACY_SMS_FRONTEND_URL, f'media/{obj.id:d}/statistics')
 
 
-class MediaSerializer(serializers.HyperlinkedModelSerializer):
+class MediaItemSerializer(serializers.HyperlinkedModelSerializer):
     """
     An individual media item.
 
@@ -41,36 +41,23 @@ class MediaSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = mpmodels.MediaItem
         fields = (
-            'id', 'name', 'description', 'duration', 'embedUrl', 'thumbnailUrl',
-            'uploadDate', 'legacy', 'key'
+            'url', 'id', 'title', 'description', 'duration', 'type', 'publishedAt',
+            'downloadable', 'language', 'copyright', 'tags', 'createdAt',
+            'updatedAt', 'posterImageUrl',
         )
 
-    # In JSON-LD, this should be "@id" but DRF doesn't make it easy to have @ signs in field naes
-    # so we rename this field in to_representation() below.
-    id = serializers.HyperlinkedIdentityField(
-        view_name='api:media_item', help_text='Unique URL for the media', read_only=True)
+        read_only_fields = (
+            'url', 'id', 'duration', 'type', 'created_at', 'updated_at', 'posterImageUrl'
+        )
+        extra_kwargs = {
+            'createdAt': {'source': 'created_at'},
+            'publishedAt': {'source': 'published_at'},
+            'updatedAt': {'source': 'updated_at'},
+            'url': {'view_name': 'api:media_item'},
+        }
 
-    key = serializers.CharField(source='id', help_text='Unique id for media', read_only=True)
-
-    name = serializers.CharField(source='title', help_text='Title of media')
-
-    description = serializers.CharField(help_text='Description of media', required=False)
-
-    duration = serializers.SerializerMethodField(
-        help_text='Duration of the media in ISO 8601 format', read_only=True)
-
-    embedUrl = serializers.SerializerMethodField(
-        help_text='A URL to retrieve an embeddable player for the media item.',
-        read_only=True)
-
-    thumbnailUrl = serializers.SerializerMethodField(
+    posterImageUrl = serializers.SerializerMethodField(
         help_text='A URL of a thumbnail/poster image for the media', read_only=True)
-
-    uploadDate = serializers.DateTimeField(
-        source='published_at', help_text='Publication time', read_only=True)
-
-    legacy = LegacySMSMediaSerializer(
-        source='sms', help_text='Information from legacy SMS', required=False, read_only=True)
 
     def create(self, validated_data):
         """
@@ -90,20 +77,22 @@ class MediaSerializer(serializers.HyperlinkedModelSerializer):
 
         return obj
 
-    def get_duration(self, obj):
-        """Return the media item's duration in ISO 8601 format."""
-        if obj.duration is None:
+    def get_posterImageUrl(self, obj):
+        if not hasattr(obj, 'jwp'):
             return None
+        return jwplatform.Video({'key': obj.jwp.key}).get_poster_url(width=640)
 
-        hours, remainder = divmod(obj.duration, 3600)
-        minutes, seconds = divmod(remainder, 60)
 
-        return "PT{:d}H{:02d}M{:02.1f}S".format(int(hours), int(minutes), seconds)
+class MediaItemLinksSerializer(serializers.Serializer):
+    legacyStatisticsUrl = serializers.SerializerMethodField()
+    embedUrl = serializers.SerializerMethodField()
+    sources = serializers.SerializerMethodField(source='*')
 
-    def get_media_id(self, obj):
+    def get_legacyStatisticsUrl(self, obj):
         if not hasattr(obj, 'sms'):
             return None
-        return obj.sms.id
+        return urlparse.urljoin(
+            settings.LEGACY_SMS_FRONTEND_URL, f'media/{obj.sms.id:d}/statistics')
 
     def get_embedUrl(self, obj):
         if not hasattr(obj, 'jwp'):
@@ -113,34 +102,6 @@ class MediaSerializer(serializers.HyperlinkedModelSerializer):
             settings.JWPLATFORM_CONTENT_BASE_URL
         )
 
-    def get_thumbnailUrl(self, obj):
-        if not hasattr(obj, 'jwp'):
-            return None
-        return [
-            jwplatform.Video({'key': obj.jwp.key}).get_poster_url(width=width)
-            for width in [1280, 640, 320]
-        ]
-
-    def to_representation(self, obj):
-        """
-        Custom to_representation() override which adds JSON-LD fields.
-
-        """
-        data = super().to_representation(obj)
-        data.update({
-            '@id': data['id'],
-            '@context': 'http://schema.org',
-            '@type': 'VideoObject',
-        })
-        del data['id']
-        return data
-
-
-class MediaDetailSerializer(MediaSerializer):
-    """
-    Serialize a media object with greater detail for an individual media detail response
-
-    """
     def get_sources(self, obj):
         if not obj.downloadable or not hasattr(obj, 'jwp'):
             return None
@@ -149,30 +110,16 @@ class MediaDetailSerializer(MediaSerializer):
 
         return SourceSerializer(video.get('sources'), many=True).data
 
-    def to_representation(self, obj):
-        """
-        Custom to_representation() subclass which examines the sources to set the "best" source
-        in contentUrl.
 
-        """
-        data = super().to_representation(obj)
-        sources = self.get_sources(obj)
+class MediaItemDetailSerializer(MediaItemSerializer):
+    """
+    Serialize a media object with greater detail for an individual media detail response
 
-        if sources is not None and len(sources) > 0:
-            audio_sources = [s for s in sources if s.get('mime_type') == 'audio/mp4']
-            video_sources = sorted(
-                (
-                    s for s in sources
-                    if s.get('mime_type') == 'video/mp4' and s.get('height') is not None
-                ),
-                key=lambda s: s.get('height'), reverse=True)
+    """
+    class Meta(MediaItemSerializer.Meta):
+        fields = MediaItemSerializer.Meta.fields + ('links',)
 
-            if len(video_sources) > 0:
-                data['contentUrl'] = video_sources[0].get('url')
-            elif len(audio_sources) > 0:
-                data['contentUrl'] = audio_sources[0].get('url')
-
-        return data
+    links = MediaItemLinksSerializer(source='*', read_only=True)
 
 
 class CollectionSerializer(serializers.Serializer):

--- a/api/tests/fixtures/mediaitems.yaml
+++ b/api/tests/fixtures/mediaitems.yaml
@@ -30,10 +30,15 @@
     updated_at: 2010-09-15 14:40:45
 
 - model: mediaplatform.Permission
-  pk: pempty
+  pk: pemptyv
   fields:
     is_public: true
     allows_view_item: empty
+
+- model: mediaplatform.Permission
+  pk: pemptye
+  fields:
+    allows_edit_item: empty
 
 - model: mediaplatform.MediaItem
   pk: deleted

--- a/api/tests/test_permissions.py
+++ b/api/tests/test_permissions.py
@@ -1,0 +1,152 @@
+from django.contrib.auth.models import AnonymousUser
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+
+import mediaplatform.models as mpmodels
+
+from .. import permissions
+
+
+class MediaItemPermissionTestCase(TestCase):
+    fixtures = ['api/tests/fixtures/mediaitems.yaml']
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.safe_request = self.factory.get('/')
+        self.unsafe_request = self.factory.post('/')
+        self.item = mpmodels.MediaItem.objects.get(id='empty')
+        self.permission = permissions.MediaItemPermission()
+        self.view = None  # if MediaItemPermission start using this, we need to set it
+
+    def test_safe_allowed_in_general(self):
+        self.assert_safe_has_permission()
+
+    def test_unsafe_not_allowed_in_general(self):
+        self.assert_unsafe_does_not_have_permission()
+
+    def test_safe_requires_viewable_object(self):
+        self.item.view_permission.reset()
+        self.item.view_permission.save()
+        self.assert_safe_object_does_not_have_permission(
+            self.fetch_item(annotate_viewable=True))
+        self.item.view_permission.is_public = True
+        self.item.view_permission.save()
+        self.assert_safe_object_has_permission(
+            self.fetch_item(annotate_viewable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_safe_object_has_permission(self.fetch_item())
+
+    def test_unsafe_requires_viewable_object(self):
+        self.item.edit_permission.reset()
+        self.item.edit_permission.is_public = True
+        self.item.edit_permission.save()
+
+        self.item.view_permission.reset()
+        self.item.view_permission.save()
+        self.assert_unsafe_object_does_not_have_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+        self.item.view_permission.is_public = True
+        self.item.view_permission.save()
+        self.assert_unsafe_object_has_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_unsafe_object_has_permission(self.fetch_item(annotate_editable=True))
+
+    def test_unsafe_requires_editable_object(self):
+        self.item.view_permission.reset()
+        self.item.view_permission.is_public = True
+        self.item.view_permission.save()
+
+        self.item.edit_permission.reset()
+        self.item.edit_permission.save()
+        self.assert_unsafe_object_does_not_have_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+        self.item.edit_permission.is_public = True
+        self.item.edit_permission.save()
+        self.assert_unsafe_object_has_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_unsafe_object_has_permission(self.fetch_item(annotate_viewable=True))
+
+    def assert_safe_has_permission(self):
+        self.assertTrue(self.permission.has_permission(self.safe_request, self.view))
+
+    def assert_safe_does_not_have_permission(self):
+        self.assertFalse(self.permission.has_permission(self.safe_request, self.view))
+
+    def assert_unsafe_has_permission(self):
+        self.assertTrue(self.permission.has_permission(self.unsafe_request, self.view))
+
+    def assert_unsafe_does_not_have_permission(self):
+        self.assertFalse(self.permission.has_permission(self.unsafe_request, self.view))
+
+    def assert_safe_object_has_permission(self, obj):
+        self.assertTrue(self.permission.has_object_permission(self.safe_request, self.view, obj))
+
+    def assert_safe_object_does_not_have_permission(self, obj):
+        self.assertFalse(self.permission.has_object_permission(self.safe_request, self.view, obj))
+
+    def assert_unsafe_object_has_permission(self, obj):
+        self.assertTrue(self.permission.has_object_permission(self.unsafe_request, self.view, obj))
+
+    def assert_unsafe_object_does_not_have_permission(self, obj):
+        self.assertFalse(self.permission.has_object_permission(
+            self.unsafe_request, self.view, obj))
+
+    def fetch_item(self, annotate_viewable=False, annotate_editable=False):
+        qs = mpmodels.MediaItem.objects.all()
+        if annotate_viewable:
+            qs = qs.annotate_viewable(AnonymousUser())
+        if annotate_editable:
+            qs = qs.annotate_editable(AnonymousUser())
+        return qs.get(id=self.item.id)
+
+
+class MediaItemEditPermissionTestCase(MediaItemPermissionTestCase):
+    def setUp(self):
+        super().setUp()
+        self.permission = permissions.MediaItemEditPermission()
+
+    def test_safe_requires_viewable_object(self):
+        self.item.edit_permission.reset()
+        self.item.edit_permission.is_public = True
+        self.item.edit_permission.save()
+
+        self.item.view_permission.reset()
+        self.item.view_permission.save()
+        self.assert_safe_object_does_not_have_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+        self.item.view_permission.is_public = True
+        self.item.view_permission.save()
+        self.assert_safe_object_has_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_safe_object_has_permission(self.fetch_item(annotate_viewable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_safe_object_has_permission(self.fetch_item(annotate_editable=True))
+
+    def test_safe_requires_editable_object(self):
+        self.item.view_permission.reset()
+        self.item.view_permission.is_public = True
+        self.item.view_permission.save()
+
+        self.item.edit_permission.reset()
+        self.item.edit_permission.save()
+
+        self.assert_safe_object_does_not_have_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+        self.item.edit_permission.is_public = True
+        self.item.edit_permission.save()
+        self.assert_safe_object_has_permission(
+            self.fetch_item(annotate_viewable=True, annotate_editable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_safe_object_has_permission(self.fetch_item(annotate_viewable=True))
+
+        with self.assertRaises(permissions.ObjectNotAnnotated):
+            self.assert_safe_object_has_permission(self.fetch_item(annotate_editable=True))

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -8,12 +8,12 @@ from .. import serializers
 class MediaItemSerializerTestCase(TestCase):
     def test_create_with_no_user(self):
         with mock.patch('mediaplatform.models.MediaItem.objects.create') as f:
-            serializers.MediaSerializer().create(validated_data={})
+            serializers.MediaItemSerializer().create(validated_data={})
         f.assert_called()
 
         request = mock.MagicMock()
         request.user.is_anonymous = False
         request.user.username = 'testuser'
         with mock.patch('mediaplatform.models.MediaItem.objects.create_for_user') as f:
-            serializers.MediaSerializer(context={'request': request}).create(validated_data={})
+            serializers.MediaItemSerializer(context={'request': request}).create(validated_data={})
         f.assert_called()

--- a/api/tests/test_serializers.py
+++ b/api/tests/test_serializers.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from django.test import TestCase
+
+from .. import serializers
+
+
+class MediaItemSerializerTestCase(TestCase):
+    def test_create_with_no_user(self):
+        with mock.patch('mediaplatform.models.MediaItem.objects.create') as f:
+            serializers.MediaSerializer().create(validated_data={})
+        f.assert_called()
+
+        request = mock.MagicMock()
+        request.user.is_anonymous = False
+        request.user.username = 'testuser'
+        with mock.patch('mediaplatform.models.MediaItem.objects.create_for_user') as f:
+            serializers.MediaSerializer(context={'request': request}).create(validated_data={})
+        f.assert_called()

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -110,10 +110,10 @@ class CollectionListViewTestCase(ViewTestCase):
         self.assertEqual(call_args[1]['search'], 'foo')
 
 
-class MediaListViewTestCase(ViewTestCase):
+class MediaItemListViewTestCase(ViewTestCase):
     def setUp(self):
         super().setUp()
-        self.view = views.MediaListView().as_view()
+        self.view = views.MediaItemListView().as_view()
 
     def test_basic_list(self):
         """An anonymous user should get expected media back."""
@@ -125,7 +125,7 @@ class MediaListViewTestCase(ViewTestCase):
 
         expected_ids = set(o.id for o in self.viewable_by_anon)
         for item in response_data['results']:
-            self.assertIn(item['key'], expected_ids)
+            self.assertIn(item['id'], expected_ids)
 
     def test_auth_list(self):
         """An authenticated user should get expected media back."""
@@ -141,13 +141,13 @@ class MediaListViewTestCase(ViewTestCase):
 
         expected_ids = set(o.id for o in self.viewable_by_user)
         for item in response_data['results']:
-            self.assertIn(item['key'], expected_ids)
+            self.assertIn(item['id'], expected_ids)
 
 
-class MediaViewTestCase(ViewTestCase):
+class MediaItemViewTestCase(ViewTestCase):
     def setUp(self):
         super().setUp()
-        self.view = views.MediaView().as_view()
+        self.view = views.MediaItemView().as_view()
         self.dv_from_key_patcher = mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
         self.dv_from_key = self.dv_from_key_patcher.start()
         self.dv_from_key.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
@@ -163,17 +163,16 @@ class MediaViewTestCase(ViewTestCase):
 
         self.dv_from_key.assert_called_with(item.jwp.key)
 
-        self.assertEqual(response.data['key'], item.id)
-        self.assertEqual(response.data['name'], item.title)
+        self.assertEqual(response.data['id'], item.id)
+        self.assertEqual(response.data['title'], item.title)
         self.assertEqual(response.data['description'], item.description)
-        self.assertEqual(dateparser.parse(response.data['uploadDate']), item.published_at)
+        self.assertEqual(dateparser.parse(response.data['publishedAt']), item.published_at)
         self.assertIn(
-            'https://cdn.jwplayer.com/thumbs/{}-1280.jpg'.format(item.jwp.key),
-            response.data['thumbnailUrl']
+            'https://cdn.jwplayer.com/thumbs/{}-640.jpg'.format(item.jwp.key),
+            response.data['posterImageUrl']
         )
         self.assertIsNotNone(response.data['duration'])
-        self.assertEqual(response.data['legacy']['id'], item.sms.id)
-        self.assertTrue(response.data['embedUrl'].startswith(
+        self.assertTrue(response.data['links']['embedUrl'].startswith(
             'https://content.jwplatform.com/players/{}-someplayer.html'.format(item.jwp.key)
         ))
 

--- a/api/urls.py
+++ b/api/urls.py
@@ -26,8 +26,8 @@ schema_view = get_schema_view(
 
 urlpatterns = [
     path('collections/', views.CollectionListView.as_view(), name='collections'),
-    path('media/', views.MediaListView.as_view(), name='media_list'),
-    path('media/<pk>', views.MediaView.as_view(), name='media_item'),
+    path('media/', views.MediaItemListView.as_view(), name='media_list'),
+    path('media/<pk>', views.MediaItemView.as_view(), name='media_item'),
     path('profile/', views.ProfileView.as_view(), name='profile'),
     re_path(
         r'^swagger(?P<format>\.json|\.yaml)$',

--- a/api/views.py
+++ b/api/views.py
@@ -110,11 +110,11 @@ class CollectionListView(APIView):
         return Response(serializers.CollectionListSerializer(channel_list).data)
 
 
-class MediaListPagination(pagination.CursorPagination):
+class MediaItemListPagination(pagination.CursorPagination):
     page_size = 50
 
 
-class MediaListSearchFilter(filters.SearchFilter):
+class MediaItemListSearchFilter(filters.SearchFilter):
     """
     Custom filter based on :py:class:`rest_framework.filters.SearchFilter` specialised to search
     :py:class:`mediaplatform.models.MediaItem` objects. If the "tags" field is specified in the
@@ -181,22 +181,22 @@ class MediaItemMixin:
         )
 
 
-class MediaListView(MediaItemListMixin, generics.ListCreateAPIView):
+class MediaItemListView(MediaItemListMixin, generics.ListCreateAPIView):
     """
     Endpoint to retrieve a list of media.
 
     """
-    filter_backends = (filters.OrderingFilter, MediaListSearchFilter)
+    filter_backends = (filters.OrderingFilter, MediaItemListSearchFilter)
     ordering = '-published_at'
     ordering_fields = ('published_at',)
-    pagination_class = MediaListPagination
+    pagination_class = MediaItemListPagination
     search_fields = ('title', 'description', 'tags')
-    serializer_class = serializers.MediaSerializer
+    serializer_class = serializers.MediaItemSerializer
 
 
-class MediaView(MediaItemMixin, generics.RetrieveUpdateAPIView):
+class MediaItemView(MediaItemMixin, generics.RetrieveUpdateAPIView):
     """
     Endpoint to retrieve a single media item.
 
     """
-    serializer_class = serializers.MediaDetailSerializer
+    serializer_class = serializers.MediaItemDetailSerializer

--- a/api/views.py
+++ b/api/views.py
@@ -153,6 +153,7 @@ class MediaItemListMixin:
         return (
             super().get_queryset().all()
             .viewable_by_user(self.request.user)
+            .annotate_viewable(self.request.user)
             .annotate_editable(self.request.user)
             .select_related('jwp')
             .select_related('sms')
@@ -173,6 +174,7 @@ class MediaItemMixin:
         return (
             super().get_queryset().all()
             .viewable_by_user(self.request.user)
+            .annotate_viewable(self.request.user)
             .annotate_editable(self.request.user)
             .select_related('jwp')
             .select_related('sms')

--- a/api/views.py
+++ b/api/views.py
@@ -15,6 +15,7 @@ from rest_framework import generics, pagination, filters
 from smsjwplatform import jwplatform
 import mediaplatform.models as mpmodels
 
+from . import permissions
 from . import serializers
 
 
@@ -138,7 +139,47 @@ class MediaListSearchFilter(filters.SearchFilter):
         return filtered_qs
 
 
-class MediaListView(generics.ListAPIView):
+class MediaItemListMixin:
+    """
+    A mixin class for DRF generic views which has all of the specialisations necessary for listing
+    (and possibly creating/deleting) media items. Use this mixin with ListAPIView or
+    ListCreateAPIView to form a concrete view class.
+
+    """
+    queryset = mpmodels.MediaItem.objects
+    permission_classes = [permissions.MediaItemPermission]
+
+    def get_queryset(self):
+        return (
+            super().get_queryset().all()
+            .viewable_by_user(self.request.user)
+            .annotate_editable(self.request.user)
+            .select_related('jwp')
+            .select_related('sms')
+        )
+
+
+class MediaItemMixin:
+    """
+    A mixin class for DRF generic views which has all of the specialisations necessary for
+    retrieving (and possibly updating) individual media items. Use this mixin with RetrieveAPIView
+    or RetrieveUpdateAPIView to form a concrete view class.
+
+    """
+    queryset = mpmodels.MediaItem.objects
+    permission_classes = [permissions.MediaItemPermission]
+
+    def get_queryset(self):
+        return (
+            super().get_queryset().all()
+            .viewable_by_user(self.request.user)
+            .annotate_editable(self.request.user)
+            .select_related('jwp')
+            .select_related('sms')
+        )
+
+
+class MediaListView(MediaItemListMixin, generics.ListCreateAPIView):
     """
     Endpoint to retrieve a list of media.
 
@@ -147,31 +188,13 @@ class MediaListView(generics.ListAPIView):
     ordering = '-published_at'
     ordering_fields = ('published_at',)
     pagination_class = MediaListPagination
-    queryset = mpmodels.MediaItem.objects
     search_fields = ('title', 'description', 'tags')
     serializer_class = serializers.MediaSerializer
 
-    def get_queryset(self):
-        return (
-            super().get_queryset().all()
-            .viewable_by_user(self.request.user)
-            .select_related('jwp')
-            .select_related('sms')
-        )
 
-
-class MediaView(generics.RetrieveAPIView):
+class MediaView(MediaItemMixin, generics.RetrieveUpdateAPIView):
     """
     Endpoint to retrieve a single media item.
 
     """
-    queryset = mpmodels.MediaItem.objects
     serializer_class = serializers.MediaDetailSerializer
-
-    def get_queryset(self):
-        return (
-            super().get_queryset().all()
-            .viewable_by_user(self.request.user)
-            .select_related('jwp')
-            .select_related('sms')
-        )

--- a/frontend/src/providers/MediaItemProvider.js
+++ b/frontend/src/providers/MediaItemProvider.js
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+import { mediaGet } from '../api';
+
+const { Provider, Consumer } = React.createContext();
+
+/**
+ * Get a media item resource and provide it to child components via the withMediaItem
+ * HoC. Before the item is fetched, the provided item is null.
+ */
+class MediaItemProvider extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { item: null };
+  }
+
+  componentWillMount() {
+    const { id } = this.props;
+    mediaGet(id).then(item => this.setState({ item }));
+  }
+
+  render() {
+    return <Provider value={ this.state.item }>{ this.props.children }</Provider>
+  }
+}
+
+MediaItemProvider.propTypes = {
+  /** Id of media item to retrieve. */
+  id: PropTypes.string.isRequired,
+};
+
+/**
+ * A higher-order component wrapper which passes the newly created media item resource to its
+ * child. The item is passed in the item prop.
+ */
+const withMediaItem = WrappedComponent => props => (
+  <Consumer>{ value => <WrappedComponent item={ value } {...props} />}</Consumer>
+);
+
+export { MediaItemProvider, withMediaItem };
+export default MediaItemProvider;

--- a/ui/serializers.py
+++ b/ui/serializers.py
@@ -1,0 +1,21 @@
+import logging
+import json
+
+from rest_framework import serializers
+
+from api import serializers as apiserializers
+
+LOG = logging.getLogger(__name__)
+
+
+class MediaItemPageSerializer(serializers.Serializer):
+    """
+    A serialiser for media items which renders one field, ``json_ld``, which is the representation
+    of the media item in JSON LD format.
+
+    """
+    json_ld = serializers.SerializerMethodField()
+
+    def get_json_ld(self, obj):
+        data = apiserializers.MediaSerializer(obj, context=self.context).data
+        return json.dumps(data)

--- a/ui/templates/ui/media.html
+++ b/ui/templates/ui/media.html
@@ -3,6 +3,6 @@
 {% block page_name %}media{% endblock %}
 {% block extrabody %}
 <script id="mediaItem" type="application/ld+json">
-{% autoescape off %}{{ media_item_json }}{% endautoescape %}
+{% autoescape off %}{{ json_ld }}{% endautoescape %}
 </script>
 {% endblock %}

--- a/ui/templates/ui/media.html
+++ b/ui/templates/ui/media.html
@@ -1,8 +1,11 @@
 {% extends 'index.html' %}
-{% block title %}{{title}}{% endblock %}
-{% block page_name %}media{% endblock %}
+{% load to_json %}
+{% block title %}{{ resource.title }}{% endblock %}
 {% block extrabody %}
-<script id="mediaItem" type="application/ld+json">
-{% autoescape off %}{{ json_ld }}{% endautoescape %}
+<script type="application/ld+json">
+{% autoescape off %}{{ json_ld|to_json }}{% endautoescape %}
+</script>
+<script type="application/resource+json">
+{% autoescape off %}{{ resource|to_json }}{% endautoescape %}
 </script>
 {% endblock %}

--- a/ui/templatetags/to_json.py
+++ b/ui/templatetags/to_json.py
@@ -1,0 +1,10 @@
+import json
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def to_json(value):
+    return json.dumps(value)

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -2,7 +2,6 @@
 Tests for views.
 
 """
-import json
 from unittest import mock
 
 from django.urls import reverse
@@ -24,7 +23,7 @@ class ViewsTestCase(ViewTestCase):
 
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/media.html')
-        media_item_json = json.loads(r.context['json_ld'])
+        media_item_json = r.context['json_ld']
         self.assertEqual(media_item_json['name'], item.title)
         self.assertIn(
             'https://cdn.jwplayer.com/thumbs/{}-1280.jpg'.format(item.jwp.key),

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -24,8 +24,8 @@ class ViewsTestCase(ViewTestCase):
 
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/media.html')
-        self.assertEqual(r.context['name'], item.title)
-        media_item_json = json.loads(r.context['media_item_json'])
+        media_item_json = json.loads(r.context['json_ld'])
+        self.assertEqual(media_item_json['name'], item.title)
         self.assertIn(
             'https://cdn.jwplayer.com/thumbs/{}-1280.jpg'.format(item.jwp.key),
             media_item_json['thumbnailUrl'],

--- a/ui/views.py
+++ b/ui/views.py
@@ -2,24 +2,23 @@
 Views
 
 """
-import json
 import logging
 
+from django.utils.decorators import method_decorator
+from drf_yasg.utils import swagger_auto_schema
+from rest_framework import generics
 from rest_framework.renderers import TemplateHTMLRenderer
 
-import api
+from api import views as apiviews
+from . import serializers
 
 LOG = logging.getLogger(__name__)
 
 
-class MediaView(api.views.MediaView):
+# The UI views are not part of the API and should not appear in the swagger docs
+@method_decorator(name='get', decorator=swagger_auto_schema(auto_schema=None))
+class MediaView(apiviews.MediaItemMixin, generics.RetrieveAPIView):
     """View for rendering an individual media item. Extends the DRF's media item view."""
-
+    serializer_class = serializers.MediaItemPageSerializer
     renderer_classes = [TemplateHTMLRenderer]
-
     template_name = 'ui/media.html'
-
-    def get(self, request, pk):
-        response = super().get(request, pk)
-        response.data['media_item_json'] = json.dumps(response.data)
-        return response


### PR DESCRIPTION
This PR tidies up our API/UI split a little bit and introduces the ability to create/update media items via the API.

Since this PR changes the API view classes to be a ListCreate and RetrieveUpdate view, we can no-longer simply derive from them for the UI. We address this by splitting the specialisations for Media item list and detail views into their own mixins and having the UI and API views inherit from those mixins.