### PR TITLE
frontend: pass Django CSRF token with API calls

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -24,6 +24,8 @@
     {% block extra_head %}{% endblock %}
   </head>
   <body>
+    {# Include Django's CSRF token in the page for the API to read. #}
+    {% csrf_token %}
     <noscript>
       You need to enable JavaScript to run this app.
     </noscript>


### PR DESCRIPTION
At the moment our only API calls are "safe" method ones which do not change state. We're going to add "unsafe" ones which do. Django's CSRF protection will kick in at that point and so we need to make sure we pass the token to Django in the HTTP headers.