### PR TITLE
tox.sh: allow writing artifacts/coverage information

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ $ ./tox.sh -e flake8
 
 # Run the migrate management command using the development images
 $ ./manage_development.sh migrate
+
+# Run tests and write coverage/documentation to build directory
+$ COMPOSE_ARGS="-v ./build:/tmp/tox-data/artefacts" ./tox.sh
 ```
 
 ## Dockerfile configuration

--- a/tox.sh
+++ b/tox.sh
@@ -10,4 +10,4 @@ cd "$( dirname "${BASH_SOURCE[0]}")"
 
 # Execute tox runner, logging command used
 set -x
-exec ./compose.sh tox run --rm tox tox $@
+exec ./compose.sh tox run --rm $COMPOSE_ARGS tox tox $@


### PR DESCRIPTION
Add the ability to pass extra arguments to compose.sh from tox.sh and add an example to the README showing how to write coverage reports to the local filesystem.