### PR TITLE
fix JSON encoding XSS vunerability

### DIFF
--- a/ui/templates/ui/media.html
+++ b/ui/templates/ui/media.html
@@ -3,9 +3,9 @@
 {% block title %}{{ resource.title }}{% endblock %}
 {% block extrabody %}
 <script type="application/ld+json">
-{% autoescape off %}{{ json_ld|to_json }}{% endautoescape %}
+{{ json_ld|to_json }}
 </script>
 <script type="application/resource+json">
-{% autoescape off %}{{ resource|to_json }}{% endautoescape %}
+{{ resource|to_json }}
 </script>
 {% endblock %}

--- a/ui/templatetags/to_json.py
+++ b/ui/templatetags/to_json.py
@@ -1,10 +1,30 @@
 import json
 
 from django import template
+from django.core.serializers.json import DjangoJSONEncoder
+from django.utils.html import format_html
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
 
+_json_script_escapes = {
+    ord('>'): '\\u003E',
+    ord('<'): '\\u003C',
+    ord('&'): '\\u0026',
+}
+
+
 @register.filter
 def to_json(value):
-    return json.dumps(value)
+    """
+    Encode a value to JSON using the DjangoJSONEncoder. Escape all the HTML/XML special characters
+    with their unicode escapes, so value is safe to be output anywhere except for inside a tag
+    attribute.
+
+    See: https://docs.djangoproject.com/en/2.1/topics/serialization/#serialization-formats-json
+    See: django.utils.html.json_script
+
+    """
+    json_str = json.dumps(value, cls=DjangoJSONEncoder).translate(_json_script_escapes)
+    return format_html('{}', mark_safe(json_str))

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -15,11 +15,11 @@ class ViewsTestCase(ViewTestCase):
         super().setUp()
         dv_patch = mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
         self.mock_from_id = dv_patch.start()
+        self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
         self.addCleanup(dv_patch.stop)
 
     def test_success(self):
         """checks that a media item is rendered successfully"""
-        self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
         item = self.non_deleted_media.get(id='populated')
 
         # test
@@ -44,22 +44,17 @@ class ViewsTestCase(ViewTestCase):
         self.assertEqual(r.status_code, 404)
 
     def test_json_ld_embedded(self):
-        """checks that HTML in descriptions, etc is correctly escaped."""
-        self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
+        """check that a JSON-LD script tag is present in the output"""
         item = self.non_deleted_media.get(id='populated')
-
-        item.title = '<script>'
-
         r = self.client.get(reverse('ui:media_item', kwargs={'pk': item.pk}))
 
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/media.html')
         content = r.content.decode('utf8')
-        print('content: ', content)
         self.assertIn('<script type="application/ld+json">', content)
 
     def test_no_html_in_page(self):
-        """checks that HTML in descriptions, etc is correctly escaped."""
+        """checks that HTML in descriptions, etc is escaped."""
         self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
         item = self.non_deleted_media.get(id='populated')
 
@@ -71,7 +66,6 @@ class ViewsTestCase(ViewTestCase):
         self.assertEqual(r.status_code, 200)
         self.assertTemplateUsed(r, 'ui/media.html')
         content = r.content.decode('utf8')
-        print('content: ', content)
         self.assertNotIn('<some-tag>', content)
 
 

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -11,11 +11,15 @@ from api.tests.test_views import ViewTestCase, DELIVERY_VIDEO_FIXTURE
 
 
 class ViewsTestCase(ViewTestCase):
+    def setUp(self):
+        super().setUp()
+        dv_patch = mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
+        self.mock_from_id = dv_patch.start()
+        self.addCleanup(dv_patch.stop)
 
-    @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
-    def test_success(self, mock_from_id):
+    def test_success(self):
         """checks that a media item is rendered successfully"""
-        mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
+        self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
         item = self.non_deleted_media.get(id='populated')
 
         # test
@@ -30,14 +34,42 @@ class ViewsTestCase(ViewTestCase):
             media_item_json['thumbnailUrl'],
         )
 
-    @mock.patch('smsjwplatform.jwplatform.DeliveryVideo.from_key')
-    def test_video_not_found(self, mock_from_id):
+    def test_video_not_found(self):
         """checks that a video not found results in a 404"""
-        mock_from_id.side_effect = api.VideoNotFoundError
+        self.mock_from_id.side_effect = api.VideoNotFoundError
 
         # test
         r = self.client.get(reverse('ui:media_item', kwargs={'pk': 'this-does-not-exist'}))
 
         self.assertEqual(r.status_code, 404)
 
-    # TODO: add ACL checks here
+    def test_json_ld_embedded(self):
+        """checks that HTML in descriptions, etc is correctly escaped."""
+        self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
+        item = self.non_deleted_media.get(id='populated')
+
+        item.title = '<script>'
+
+        r = self.client.get(reverse('ui:media_item', kwargs={'pk': item.pk}))
+
+        self.assertEqual(r.status_code, 200)
+        self.assertTemplateUsed(r, 'ui/media.html')
+        content = r.content.decode('utf8')
+        print('content: ', content)
+        self.assertIn('<script type="application/ld+json">', content)
+
+    def test_no_html_in_page(self):
+        """checks that HTML in descriptions, etc is correctly escaped."""
+        self.mock_from_id.return_value = api.DeliveryVideo(DELIVERY_VIDEO_FIXTURE)
+        item = self.non_deleted_media.get(id='populated')
+
+        item.title = '<some-tag>'
+        item.save()
+
+        r = self.client.get(reverse('ui:media_item', kwargs={'pk': item.pk}))
+
+        self.assertEqual(r.status_code, 200)
+        self.assertTemplateUsed(r, 'ui/media.html')
+        content = r.content.decode('utf8')
+        print('content: ', content)
+        self.assertNotIn('<some-tag>', content)


### PR DESCRIPTION
The to_json filter tag did not escape HTML special characters within strings meaning that any resource which had, e.g., a description with closing <script> tag in it could trivially perform a XSS attack.

Update the tag with an implementation inspired by the new json_script tag from Django 2.1. We cannot use the json_script tag directly because we add more information to our script tags than simply the id.