### PR TITLE
port to Django 2.1 and Python 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ADD ./frontend/ ./
 RUN npm install && npm run build
 
 # Use python alpine image to run webapp proper
-FROM uisautomation/django:2.0-py3.6
+FROM uisautomation/django:2.1-py3.7
 
 # Ensure packages are up to date and install some useful utilities
 RUN apk update && apk add git vim postgresql-dev libffi-dev gcc musl-dev \

--- a/compose/development.django.Dockerfile
+++ b/compose/development.django.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6
+FROM python:3.7
 
 # Do everything relative to /usr/src/app which is where we install our
 # application.

--- a/doc/developer.rst
+++ b/doc/developer.rst
@@ -65,8 +65,8 @@ tox environments
 
 The following tox environments are available.
 
-py36
-    Run by default. Launch the test suite under Python 3.6. Generate a
+py3
+    Run by default. Launch the test suite under Python 3. Generate a
     code-coverage report and display a summary coverage report.
 
 doc

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # Requirements for the webapp itself
-django>=2.0
+django>=2.1,<2.2
 psycopg2-binary
 # explicitly specify django-automationcommon's git repo since changes in
 # automationcommon tend to be "ad hoc" and may need testing here without a
@@ -7,7 +7,7 @@ psycopg2-binary
 # in the VCS URL.
 git+https://github.com/uisautomation/django-automationcommon.git@master#egg=django-automationcommon
 git+https://github.com/uisautomation/django-automationoauth.git@master#egg=django-automationoauth
-django-ucamwebauth>=1.4.5
+django-ucamwebauth>=1.4.8
 djangorestframework
 django-cors-headers
 drf-yasg

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@
 #
 [tox]
 # Envs which should be run by default.
-envlist=flake8,doc,py36
+envlist=flake8,doc,py3
 # Allow overriding toxworkdir via environment variable
 toxworkdir={env:TOXINI_WORK_DIR:{toxinidir}/.tox}
 # We do not actually ship a setup.py file which is used by our deployment.
@@ -69,9 +69,12 @@ commands=
 # over and over again.
 sitepackages={env:TOXINI_SITEPACKAGES:False}
 
+[testenv:py3]
+basepython=python3
+
 # Build documentation
 [testenv:doc]
-basepython=python3.6
+basepython=python3
 deps=
     -rrequirements/base.txt
     -rdoc/requirements.txt
@@ -79,7 +82,7 @@ commands=sphinx-build -a -v -b html doc/ {[_vars]build_root}/doc/
 
 # Check for PEP8 violations
 [testenv:flake8]
-basepython=python3.6
+basepython=python3
 deps=
     -rrequirements/base.txt
 #   We specify a specific version of flake8 to avoid introducing "false"
@@ -92,6 +95,6 @@ commands=
 
 # Run management commands
 [testenv:manage]
-basepython=python3.6
+basepython=python3
 commands=
     ./manage.py {posargs}


### PR DESCRIPTION
Update the portions of our development and production packaging which specify Django 2.0 and Python 3.6 to talk about Django 2.1 and Python 3.7. Bump the minimum required version of django-ucamwebauth to be Django 2.1 compatible.

Make tox neutral on the precise version of Python it uses (beyond Python3) since we always run tox inside a container and it should just use whatever Python 3 is given to it.