### PR TITLE
mediaplatform: remove concept of "orphan channel"

### DIFF
--- a/mediaplatform/migrations/0006_link_media_items_to_channel.py
+++ b/mediaplatform/migrations/0006_link_media_items_to_channel.py
@@ -2,17 +2,6 @@
 
 from django.db import migrations, models
 import django.db.models.deletion
-import mediaplatform.models
-
-
-def reverse_orphan_channel(apps, schema_editor):
-    # We do not undo create_orphan_channel() since it is fine for it to continue to exist when
-    # reversing this migration. We need to have a reverse form to placate Django, though.
-    pass
-
-
-def create_orphan_channel(apps, schema_editor):
-    mediaplatform.models.get_orphan_channel_id()
 
 
 class Migration(migrations.Migration):
@@ -22,10 +11,9 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(create_orphan_channel, reverse_code=reverse_orphan_channel),
         migrations.AddField(
             model_name='mediaitem',
             name='channel',
-            field=models.ForeignKey(default=mediaplatform.models.get_orphan_channel_id, help_text='Channel containing media item', on_delete=django.db.models.deletion.SET_DEFAULT, related_name='items', to='mediaplatform.Channel'),
+            field=models.ForeignKey(null=True, help_text='Channel containing media item', on_delete=django.db.models.deletion.SET_NULL, related_name='items', to='mediaplatform.Channel'),
         ),
     ]

--- a/mediaplatform/models.py
+++ b/mediaplatform/models.py
@@ -32,18 +32,6 @@ def _make_token():
 #: ids used by YouTube which suggests there'll be enough entropy for the time being.
 _TOKEN_LENGTH = len(_make_token())
 
-#: Special id reserved for the orphan channel.
-_ORPHAN_CHANNEL_ID = '!!ORPHAN!!'
-
-
-def get_orphan_channel_id():
-    """
-    Get the id of the dedicated channel for "orphaned" media items. The channel is created if if
-    does not exist.
-
-    """
-    return Channel.objects.get_or_create(id=_ORPHAN_CHANNEL_ID, title='Orphaned media items')[0].id
-
 
 def _blank_array():
     """
@@ -205,10 +193,10 @@ class MediaItem(models.Model):
     id = models.CharField(
         max_length=_TOKEN_LENGTH, primary_key=True, default=_make_token, editable=False)
 
-    #: Channel which contains media item
+    #: Channel which contains media item - if NULL, then the media item is in no channel.
     channel = models.ForeignKey(
-        'Channel', help_text='Channel containing media item', default=get_orphan_channel_id,
-        on_delete=models.SET_DEFAULT, related_name='items')
+        'Channel', help_text='Channel containing media item', null=True,
+        on_delete=models.SET_NULL, related_name='items')
 
     #: Media item title
     title = models.TextField(help_text='Title of media item', blank=True, default='')


### PR DESCRIPTION
The orphan channel migration was causing problems as creating objects from within migrations causes signal handlers to be called which expect the database to be in a certain state.

Replace the "orphan" channel with the channel of the media item being "NULL".