### PR TITLE
bugfix: we get 404 if the JW video is not yet available

### DIFF
--- a/api/serializers.py
+++ b/api/serializers.py
@@ -107,7 +107,7 @@ class MediaItemLinksSerializer(serializers.Serializer):
 
     def get_sources(self, obj):
         if not obj.downloadable or not hasattr(obj, 'jwp'):
-            return None
+            return []
 
         try:
             video = jwplatform.DeliveryVideo.from_key(obj.jwp.key)
@@ -115,7 +115,7 @@ class MediaItemLinksSerializer(serializers.Serializer):
             # this can occur if the video is still transcoding - better to set the sources to none
             # than fail completely
             LOG.warning("unable to generate download sources as the JW video is not yet available")
-            return None
+            return []
 
         return SourceSerializer(video.get('sources'), many=True).data
 

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -163,6 +163,17 @@ class MediaItemViewTestCase(ViewTestCase):
             response = self.view(self.get_request, pk=obj.id)
             self.assertEqual(response.status_code, 200)
 
+    def test_success_if_jw_item_not_yet_available(self):
+        """Check that the get still succeeds, even tho the JW api throws a VideoNotFoundError"""
+        self.dv_from_key.side_effect = api.VideoNotFoundError
+        item = self.non_deleted_media.get(id='populated')
+
+        # test
+        response = self.view(self.get_request, pk=item.id)
+        self.assertEqual(response.status_code, 200)
+        # sources cannot be generated and so are set as None
+        self.assertIsNone(response.data['sources'])
+
 
 class UploadEndpointTestCase(ViewTestCase):
     fixtures = ['api/tests/fixtures/mediaitems.yaml']

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -171,8 +171,8 @@ class MediaItemViewTestCase(ViewTestCase):
         # test
         response = self.view(self.get_request, pk=item.id)
         self.assertEqual(response.status_code, 200)
-        # sources cannot be generated and so are set as None
-        self.assertFalse(response.data['links']['sources'])
+        # sources cannot be generated and so are set as []
+        self.assertEqual(response.data['links']['sources'], [])
 
 
 class UploadEndpointTestCase(ViewTestCase):

--- a/api/tests/test_views.py
+++ b/api/tests/test_views.py
@@ -172,7 +172,7 @@ class MediaItemViewTestCase(ViewTestCase):
         response = self.view(self.get_request, pk=item.id)
         self.assertEqual(response.status_code, 200)
         # sources cannot be generated and so are set as None
-        self.assertIsNone(response.data['sources'])
+        self.assertFalse(response.data['links']['sources'])
 
 
 class UploadEndpointTestCase(ViewTestCase):


### PR DESCRIPTION
We need to query the JW api to generate the download sources. However if the video is still transcoding this will fail and was resulting in a 404. Better to set the sources to none and log a warning.