### PR TITLE
Freshen the about page

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -8,6 +8,7 @@ import ChannelPage from './pages/ChannelPage';
 import IndexPage from './pages/IndexPage';
 import MediaPage from './pages/MediaPage';
 import PlaylistPage from './pages/PlaylistPage';
+import StaticTextPage from './pages/StaticTextPage';
 import UploadPage from './pages/UploadPage';
 
 ReactDOM.render(
@@ -19,6 +20,7 @@ ReactDOM.render(
       <Route exact={true} path="/upload" component={UploadPage} />
       <Route exact={true} path="/channels/:pk" component={ChannelPage} />
       <Route exact={true} path="/playlists/:pk" component={PlaylistPage} />
+      <Route exact={true} path="/about" component={StaticTextPage} />
     </div>
   </BrowserRouter>,
   document.getElementById('app')

--- a/frontend/src/pages/StaticTextPage.js
+++ b/frontend/src/pages/StaticTextPage.js
@@ -1,0 +1,57 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Grid from '@material-ui/core/Grid';
+import Paper from '@material-ui/core/Paper';
+import { withStyles } from '@material-ui/core/styles';
+
+import Page from '../containers/Page';
+import RenderedMarkdown from '../components/RenderedMarkdown';
+
+class StaticTextPage extends React.Component {
+  state = { source: null };
+
+  componentDidMount() {
+    // When the component mounts, scan the document for a script tag containing the markdown source
+    // for the page.
+    const bodyElement = document.getElementById('bodySource');
+    if(bodyElement) { this.setState({ source: bodyElement.text }); }
+  }
+
+  render() {
+    const { classes } = this.props;
+    const { source } = this.state;
+    return <Page>
+      <Grid container justify='center' className={ classes.container }>
+        <Grid item component={Paper} xl={4} lg={6} md={8} sm={10} xs={12} className={ classes.paper }>
+          <RenderedMarkdown source={ source || '' } />
+        </Grid>
+      </Grid>
+    </Page>
+  }
+}
+
+StaticTextPage.propTypes = {
+  classes: PropTypes.object.isRequired,
+};
+
+const styles = theme => ({
+  container: {
+    marginTop: theme.spacing.unit * 2,
+  },
+
+  paper: {
+    padding: [[theme.spacing.unit * 2, theme.spacing.unit * 3]],
+    textAlign: 'justify',
+
+    '& a': {
+      '&:hover': {
+        textDecoration: 'underline',
+      },
+      color: theme.palette.primary.main,
+      textDecoration: 'none',
+    },
+  },
+});
+
+export default withStyles(styles)(StaticTextPage);

--- a/ui/templates/ui/about.html
+++ b/ui/templates/ui/about.html
@@ -7,7 +7,7 @@ The University of Cambridge Media Platform is a cloud based service which allows
 University staff to provide audio and video content to a target audience.  It is
 intended as a replacement for the [Streaming Media
 Service](https://sms.cam.ac.uk/). The platform is a partially featured
-prototype and shares the Streaming Media Service data.  So content uploaded to
+prototype and shares the Streaming Media Service data. Therefore content uploaded to
 and managed in the Streaming Media Service can be searched and viewed in The
 Media Platform. Additionally, user access set in the Streaming Media Service is
 respected by The Media Platform.

--- a/ui/templates/ui/about.html
+++ b/ui/templates/ui/about.html
@@ -1,93 +1,40 @@
-{% load static %}
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-    <meta name="theme-color" content="#000000">
+{% extends 'ui/statictext.html' %}
+{% block title %}About The University of Cambridge Media Platform{% endblock %}
+{% block markdown %}
+# About the Media Platform
 
-    <link rel="shortcut icon" href="/favicon.png">
+The University of Cambridge Media Platform is a cloud based service which allows
+University staff to provide audio and video content to a target audience.  It is
+intended as a replacement for the [Streaming Media
+Service](https://sms.cam.ac.uk/). The platform is a partially featured
+prototype and shares the Streaming Media Service data.  So content uploaded to
+and managed in the Streaming Media Service can be searched and viewed in The
+Media Platform. Additionally, user access set in the Streaming Media Service is
+respected by The Media Platform.
 
-    <title>About The University of Cambridge Media Platform</title>
-    <style>
-      body {
-        background-color: #f3f3f3;
-        font-family: "Roboto", "Helvetica", "Arial", sans-serif;
-        line-height: 1.6em;
-        font-size: 18px;
-      }
-      .paper {
-        margin: 60px 120px;
-        padding: 16px 24px;
-        background-color: white;
-        border-radius: 2px;
-        box-shadow: 0px 1px 5px  0px rgba(0, 0, 0, 0.2 ),
-                    0px 2px 2px  0px rgba(0, 0, 0, 0.14),
-                    0px 3px 1px -2px rgba(0, 0, 0, 0.12);
-      }
-      .wrapper {
-        justify-content: center;
-        display: flex;
-        flex-wrap: wrap;
-        box-sizing: border-box;
-      }
-      .frame {
-        max-width: 50%;
-        flex-basis: 50%;
-        flex: 0 0 auto;
-        margin: 0;
-        box-sizing: border-box;
-      }
-      h2 {
-        color: #00b1c1;
-        font-weight: ;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="paper">
-      <div class="wrapper">
-        <div class="frame">
-          <h2>The University of Cambridge Media Platform</h2>
-          <p>
-            The University of Cambridge Media Platform is a cloud based service which allows University staff to provide
-            audio and video content to a target audience.
-            It is intended as a replacement for the
-            <a target="_blank" href="https://sms.cam.ac.uk/">Streaming Media Service</a>.
-            The platform is a partially featured prototype and shares the Streaming Media Service data.
-            So content uploaded to and managed in the Streaming Media Service can be searched and viewed in
-            The Media Platform. Additionally, user access set in the Streaming Media Service is respected by
-            The Media Platform.
-          </p>
-          <h2>What we mean by an <b>Alpha</b> release</h2>
-          <p>
-            We have built a prototype for our platform and would like to test this prototype with users.
-            During this testing we expect to find problems with our design and decide how to fix them.
-            By the end of the testing we will be in a position to decide whether or not to take the platform into a beta
-            phase and what we need to build in that phase.
-          </p><p>
-            For a fuller definition
-            <a target="_blank" href="https://www.gov.uk/service-manual/agile-delivery/how-the-alpha-phase-works">
-              please read this<!--
-            --></a>.
-          </p>
-          <h2 id="help-us">How you can give us feedback</h2>
-          <p>
-            We'd really appreciate any feedback on The Media Platform, and the experience you've had so far.
-            This could be areas of improvement, future feature requests, or issues that you're having using the product.
-          </p><p>
-            The user-experience team can be contacted at: media@uis.cam.ac.uk
-          </p>
-          <h2>For Developers</h2>
-          <p>
-            You can get the latest source code from our
-            <a target="_blank" href="https://github.com/uisautomation/sms-webapp">Git repository</a>
-            and contribute by
-            <a target="_blank" href="https://github.com/uisautomation/sms-webapp/issues">raising issues</a>
-            and submitting pull requests.
-          </p>
-        </div>
-      </div>
-    </div>
-  </body>
-</html>
+## What we mean by an "Alpha" release
+
+We have built a prototype for our platform and would like to test this prototype with users.
+During this testing we expect to find problems with our design and decide how to fix them.
+By the end of the testing we will be in a position to decide whether or not to take the platform into a beta
+phase and what we need to build in that phase.
+
+The Government Digital Services team has put together a [document describing the
+alpha phase in more
+detail](https://www.gov.uk/service-manual/agile-delivery/how-the-alpha-phase-works").
+
+## How you can give us feedback
+
+We'd really appreciate any feedback on The Media Platform, and the experience you've had so far.
+This could be areas of improvement, future feature requests, or issues that you're having using the product.
+
+The user-experience team can be contacted at:
+[media@uis.cam.ac.uk](mailto:media@uis.cam.ac.uk).
+
+## For Developers
+
+You can get the latest source code from our [Git
+repository](https://github.com/uisautomation/sms-webapp) and contribute by
+[raising issues](https://github.com/uisautomation/sms-webapp/issues) and
+submitting pull requests.
+{% endblock %}

--- a/ui/templates/ui/about.html
+++ b/ui/templates/ui/about.html
@@ -8,9 +8,9 @@ University staff to provide audio and video content to a target audience.  It is
 intended as a replacement for the [Streaming Media
 Service](https://sms.cam.ac.uk/). The platform is a partially featured
 prototype and shares the Streaming Media Service data. Therefore content uploaded to
-and managed in the Streaming Media Service can be searched and viewed in The
+and managed in the Streaming Media Service can be searched and viewed in the
 Media Platform. Additionally, user access set in the Streaming Media Service is
-respected by The Media Platform.
+respected by the Media Platform.
 
 ## What we mean by an "Alpha" release
 
@@ -28,7 +28,7 @@ detail](https://www.gov.uk/service-manual/agile-delivery/how-the-alpha-phase-wor
 We'd really appreciate any feedback on The Media Platform, and the experience you've had so far.
 This could be areas of improvement, future feature requests, or issues that you're having using the product.
 
-The user-experience team can be contacted at:
+The User Experience team can be contacted at:
 [media@uis.cam.ac.uk](mailto:media@uis.cam.ac.uk).
 
 ## For Developers

--- a/ui/templates/ui/statictext.html
+++ b/ui/templates/ui/statictext.html
@@ -1,0 +1,6 @@
+{% extends 'index.html' %}
+{% block extrabody %}
+<script type="text/markdown" id="bodySource">
+{% block markdown %}{% endblock %}
+</script>
+{% endblock %}


### PR DESCRIPTION
This PR updates the about page to be rendered in a form which is more consistent with our visual style. We add a new page component, StaticTextPage, which renders markdown source from an embedded script tag in the page.