### PR TITLE
ui: add support for Google "Global Tags"

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,3 +1,4 @@
+{% load gtag_script_tag %}
 <!DOCTYPE html>
 <html lang="en">
   <head>
@@ -22,6 +23,7 @@
     <title>{% block title %}The University of Cambridge Media Platform{% endblock %}</title>
 
     {% block extra_head %}{% endblock %}
+    {% gtag_script_tag %}
   </head>
   <body>
     {# Include Django's CSRF token in the page for the API to read. #}

--- a/smswebapp/settings/base.py
+++ b/smswebapp/settings/base.py
@@ -254,3 +254,5 @@ else:
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
 LOOKUP_SCHEME = 'crsid'
+
+GTAG_ID = os.environ.get('GTAG_ID', '')

--- a/ui/templatetags/gtag_script_tag.py
+++ b/ui/templatetags/gtag_script_tag.py
@@ -1,0 +1,32 @@
+from django import template
+from django.conf import settings
+from django.utils.html import format_html
+
+
+register = template.Library()
+
+
+@register.simple_tag
+def gtag_script_tag():
+    """
+    Render Google "Global Site Tag" HTML for, e.g., Google Analytics if the GTAG_ID setting is
+    present, non-None and non-empty. If the GTAG_ID setting is not present, None or empty, renders
+    the empty string.
+
+    """
+    if not hasattr(settings, 'GTAG_ID'):
+        return ''
+
+    gtag_id = settings.GTAG_ID
+    if gtag_id is None or gtag_id == '':
+        return ''
+
+    return format_html(r'''<!-- Global site tag (gtag.js) - Google Analytics -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={gtag_id}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){{dataLayer.push(arguments);}}
+  gtag('js', new Date());
+
+  gtag('config', '{gtag_id}');
+</script>''', gtag_id=gtag_id)


### PR DESCRIPTION
Google Analytics recommends using Google's "gtag" system which allows one to place all manner of analytics tokens into a page (including Google Analytics). Add a new template tag, gtag_script_tag, which will render the Google Analytics suggested code if the GTAG_ID setting is present. This setting is loaded, by default, from the GTAG_ID environment variable so can be customised per deployment.