### PR TITLE
add Django robots.txt and sitemap framework

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,6 +15,7 @@ iso-639
 python-dateutil
 django-crispy-forms
 django-filter
+django-robots
 
 # PRE-RELEASE WHITENOISE VERSION
 # We need at least version 4 of whitenoise to make use of the index_file

--- a/smswebapp/settings/base.py
+++ b/smswebapp/settings/base.py
@@ -25,6 +25,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'whitenoise.runserver_nostatic',  # use whitenoise even in development
     'django.contrib.staticfiles',
+    'django.contrib.sites',
+    'django.contrib.sitemaps',
 
     'automationcommon',
     'automationlookup',
@@ -35,6 +37,7 @@ INSTALLED_APPS = [
     'drf_yasg',
     'rest_framework',
     'ucamwebauth',
+    'robots',
 
     'smsjwplatform',
     'legacysms',
@@ -256,3 +259,7 @@ SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 LOOKUP_SCHEME = 'crsid'
 
 GTAG_ID = os.environ.get('GTAG_ID', '')
+
+SITE_ID = 1
+
+ROBOTS_USE_SCHEME_IN_HOST = True

--- a/smswebapp/test/test_robots.py
+++ b/smswebapp/test/test_robots.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+
+
+class RobotsTxtTestCase(TestCase):
+    def test_robots_txt_render(self):
+        "A robots.txt is available"
+        r = self.client.get('/robots.txt')
+        self.assertEqual(r.status_code, 200)

--- a/smswebapp/test/test_sitemap.py
+++ b/smswebapp/test/test_sitemap.py
@@ -1,0 +1,8 @@
+from django.test import TestCase
+
+
+class SitemapTestCase(TestCase):
+    def test_sitemap_render(self):
+        "A sitemap is available at /sitemap.xml"
+        r = self.client.get('/sitemap.xml')
+        self.assertEqual(r.status_code, 200)

--- a/smswebapp/urls.py
+++ b/smswebapp/urls.py
@@ -15,11 +15,13 @@ Including another URLconf
 """
 from django.conf import settings
 from django.contrib import admin
+from django.contrib.sitemaps.views import sitemap
 from django.urls import path, include
 
 import automationcommon.views
 
 from . import apiurls
+from ui.sitemaps import sitemaps
 
 # Django debug toolbar is only installed in developer builds
 try:
@@ -34,6 +36,9 @@ urlpatterns = [
     path('healthz', automationcommon.views.status, name='status'),
     path('legacy/', include('legacysms.urls', namespace='legacysms')),
     path('', include('ui.urls', namespace='ui')),
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps},
+         name='django.contrib.sitemaps.views.sitemap'),
+    path('robots.txt', include('robots.urls')),
 ] + apiurls.urlpatterns
 
 # Selectively enable django debug toolbar URLs. Only if the toolbar is

--- a/ui/sitemaps.py
+++ b/ui/sitemaps.py
@@ -1,0 +1,60 @@
+"""
+Sitemap objects for use with the Django sitemap framework
+(https://docs.djangoproject.com/en/2.1/ref/contrib/sitemaps/).
+
+"""
+
+from django.contrib.sitemaps import Sitemap
+from django.urls import reverse
+
+from mediaplatform import models as mpmodels
+
+
+class MediaSitemap(Sitemap):
+    """
+    A sitemap object for all media items on the site.
+
+    """
+    changefreq = 'monthly'
+    priority = 0.5
+
+    def items(self):
+        # We only show the most recently updated media items in the sitemap to avoid the sitemap
+        # being an open DoS target
+        return (
+            mpmodels.MediaItem.objects.all().viewable_by_user(None)
+            .order_by('-updated_at')[:200]
+        )
+
+    def lastmod(self, obj):
+        return obj.updated_at
+
+    def location(self, obj):
+        return reverse('ui:media_item', kwargs={'pk': obj.id})
+
+
+class StatcViewSitemap(Sitemap):
+    """
+    A sitemap object for the static views on the site.
+
+    """
+    changefreq = 'hourly'
+    priority = 0.5
+
+    def items(self):
+        return ['home']
+
+    def location(self, obj):
+        return reverse(f'ui:{obj}')
+
+
+# A sitemaps mapping for passing to the sitemaps framework in the top-level urlconf. Use like:
+#
+#     from api.sitemaps import sitemaps
+#
+#     path('sitemap.xml', sitemap, {'sitemaps': sitemaps},
+#          name='django.contrib.sitemaps.views.sitemap'),
+sitemaps = {
+    'media': MediaSitemap,
+    'static': StatcViewSitemap,
+}


### PR DESCRIPTION
Add django-robots and django.contrib.sitemaps applications and provide some configuration for the sitemaps.

The sitemap is configured at the moment to include the 200 most recently updated media items and the index page. As we add channel views, etc, we should add them to the sitemap to help Search Engines out.

The actual configuration of the robots.txt is via the Djano sites framework and is performed in the admin so, once deployed, there is a chore to go and configure all the sites.

The sites framework records the domain name of the site in the database.  The default post_migration hook creates an "example.com" entry which also needs modifying in the admin on all the deployed sites.

Closes #173