### PR TITLE
ie11 fix

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -43,7 +43,7 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
     <!-- Polyfill for IE11, etc. -->
-    <script src="https://cdn.polyfill.io/v2/polyfill.min.js"></script>
+    <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find"></script>
 
     <!-- Warn users about old browsers -->
     <script>


### PR DESCRIPTION
polyfill does not adds support for Array.prototype.find by default. We need to add it manually.