### PR TITLE
enable Django Debug Toolbar

### DIFF
--- a/smswebapp/settings/developer.py
+++ b/smswebapp/settings/developer.py
@@ -48,3 +48,15 @@ OAUTH2_TOKEN_URL = 'http://hydra:4444/oauth2/token'
 LOOKUP_ROOT = 'http://lookupproxy:8080/'
 
 LOOKUP_SCHEME = 'mock'
+
+
+def _show_toolbar(request):
+    from django.conf import settings
+    return settings.DEBUG
+
+
+DEBUG_TOOLBAR_CONFIG = {
+    # Bypass the INTERNAL_IPS check since, within the development docker container, we don't know
+    # what the host IP is likely to be.
+    'SHOW_TOOLBAR_CALLBACK': _show_toolbar,
+}

--- a/smswebapp/urls.py
+++ b/smswebapp/urls.py
@@ -25,7 +25,7 @@ from ui.sitemaps import sitemaps
 
 # Django debug toolbar is only installed in developer builds
 try:
-    import debug_toolbar.urls
+    import debug_toolbar
     HAVE_DDT = True
 except ImportError:
     HAVE_DDT = False
@@ -45,5 +45,5 @@ urlpatterns = [
 # installed *and* DEBUG is True.
 if HAVE_DDT and settings.DEBUG:
     urlpatterns = [
-        path(r'^__debug__/', include(debug_toolbar.urls)),
+        path(r'__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns


### PR DESCRIPTION
Although we had some configuration for DDT in our application, it did not result in the DDT being rendered.

1. The "HAVE_DDT" check was wrong. We should be trying to import the debug_toolbar module (as noted in the DDT docs) and not debug_toolbar.urls. We were also using path() incorrectly even if HAVE_DDT ended up True.

2. DDT only displays if a) DEBUG is True and b) the IP requesting the page is in INTERNAL_IPS. When running inside a Docker container, we do not, in general, know the IP of the host and so we need to modify the check to only be a DEBUG check.