### PR TITLE
Selenium/WebDriver (WIP: DO NOT MERGE)

### DIFF
--- a/compose/browserstack.Dockerfile
+++ b/compose/browserstack.Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:latest
+
+RUN apt-get -y update && apt-get -y install curl && \
+    curl -L -o /usr/local/bin/BrowserStackLocal \
+        https://s3.amazonaws.com/browserStack/browserstack-local/BrowserStackLocal-linux-x64 && \
+    chmod +x /usr/local/bin/BrowserStackLocal
+
+ADD ./browserstack.sh ./
+
+ENTRYPOINT ["./browserstack.sh"]

--- a/compose/browserstack.sh
+++ b/compose/browserstack.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+if [ -z "${BROWSERSTACK_ACCESS_KEY}" ]; then
+  echo "BROWSERSTACK_ACCESS_KEY not set, exiting."
+  env
+else
+  /usr/local/bin/BrowserStackLocal --key "${BROWSERSTACK_ACCESS_KEY}" --force-local
+fi

--- a/compose/tox.yml
+++ b/compose/tox.yml
@@ -9,9 +9,14 @@ services:
     build:
       context: ..
       dockerfile: ./Dockerfile
+      args:
+        tox: 1
     command: ["tox"]
+    expose:
+      - "8000"
     depends_on:
       - "db"
+      - "browserstack"
     # Mount the local directory inside the container as a volume to allow local
     # changes to be reflected without having to re-build the container.
     volumes:
@@ -23,6 +28,15 @@ services:
     env_file:
       - base.env
       - tox.env
+    environment:
+      TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR: ${TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR}
+
+  browserstack:
+    build:
+      context: .
+      dockerfile: browserstack.Dockerfile
+    environment:
+      BROWSERSTACK_ACCESS_KEY: ${BROWSERSTACK_ACCESS_KEY}
 
 volumes:
   # A persistent volume for tox to store its stuff. This allows caching of

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,8 +36,5 @@ pyjwt
 # For an improved ./manage.py shell experience
 ipython
 
-# So that tests may be run within the container
-tox
-
 # Serving
 gunicorn

--- a/requirements/developer.txt
+++ b/requirements/developer.txt
@@ -8,6 +8,8 @@ django-debug-toolbar
 
 # Testing
 tox
+selenium
+browserstack-local
 
 # docker compatible debugger
 pudb

--- a/requirements/tox.txt
+++ b/requirements/tox.txt
@@ -1,0 +1,3 @@
+# Additional requirements for the production container when running the tox test
+# runner
+tox

--- a/smswebapp/settings/tox.py
+++ b/smswebapp/settings/tox.py
@@ -11,6 +11,8 @@ import os
 # Import settings from the base settings file
 from .base import *  # noqa: F401, F403
 
+#: Don't run in DEBUG mode under tox
+DEBUG = False
 
 #: The default test runner is changed to one which captures stdout and stderr
 #: when running tests.
@@ -48,3 +50,11 @@ LOGGING = None
 
 #: Do not synchronise items using the JWP API unless tests expect it
 JWP_SYNC_ITEMS = False
+
+#: URL for selenium web driver executor. Blank if we should skip selenium tests.
+TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR = os.environ.get(
+    'TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR', '')
+
+#: Hostname to bind live server test cases to when launching the server
+TESTUTILS_LIVE_SERVER_TEST_CASE_HOST = os.environ.get(
+    'TESTUTILS_LIVE_SERVER_TEST_CASE_HOST', 'tox')

--- a/testutils/selenium.py
+++ b/testutils/selenium.py
@@ -1,0 +1,124 @@
+"""
+Utilities for interacting with selenium tests.
+
+"""
+import atexit
+import functools
+import unittest
+import urllib.parse
+
+from django.conf import settings
+from django.test import LiveServerTestCase
+from django.urls import reverse
+from selenium import webdriver
+from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
+from browserstack.local import Local
+
+
+BROWSER_CAPS = [
+    {
+        'browser': 'IE',
+        'browser_version': '11.0',
+        'os': 'Windows',
+        'os_version': '7',
+    },
+    DesiredCapabilities.CHROME,
+    DesiredCapabilities.FIREFOX,
+]
+
+
+def with_webdrivers(f):
+    """
+    Decorator for a test suite or individual tests which passes a web driver instance as the first
+    argument. Runs the decorated function once per driver using TestCase.subTest. Will skip the
+    test if a selenium command executor is not set.
+
+    To ensure speedy test runs, the drivers are cached and shared between tests. This is non-ideal
+    from a test isolation perspective but makes the test suite run far faster.
+
+    Note: this decorator should be within a LiveServerTestCase if it is to have any effect. E.g:
+
+    .. code::
+
+        class MyTestCase(LiveServerTestCase):
+            @with_webdrivers
+            def test_some_thing(self, driver):
+                # ...
+
+    """
+    url = getattr(settings, 'TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR', '')
+
+    @unittest.skipIf(url == '', 'TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR is not set')
+    @functools.wraps(f)
+    def wrapper(self, *args, **kwargs):
+        for driver in get_drivers():
+            with self.subTest(driver=driver):
+                self.driver = driver
+                f(self, *args, **kwargs)
+    return wrapper
+
+
+def get_drivers():
+    """
+    Get a list of webdriver drivers for the application. The return value is cached and so it is
+    safe to call this multiple times.
+
+    If the TESTUTILS_WEBDRIVER_BROWSERSTACK_ACCESS_KEY setting is present and non-empty, a
+    browerstack local proxy is spun up as well.
+
+    """
+    url = getattr(settings, 'TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR', '')
+    access_key = getattr(settings, 'TESTUTILS_WEBDRIVER_BROWSERSTACK_ACCESS_KEY', '')
+    binary_path = getattr(settings, 'TESTUTILS_WEBDRIVER_BROWSERSTACKLOCAL_PATH', None)
+
+    if access_key != '' and not hasattr(get_drivers, '__cached_local'):
+        start_kwargs = {'key': access_key}
+        if binary_path is not None:
+            start_kwargs['binarypath'] = binary_path
+        get_drivers.__cached_local = Local()
+        atexit.register(get_drivers.__cached_local.stop)
+        get_drivers.__cached_local.start(**start_kwargs)
+
+    if not hasattr(get_drivers, '__cached_drivers'):
+        if url == '':
+            get_drivers.__cached_drivers = []
+        else:
+            get_drivers.__cached_drivers = [
+                webdriver.Remote(
+                    command_executor=url,
+                    desired_capabilities={'browserstack.local': True, **cap}
+                )
+                for cap in BROWSER_CAPS
+            ]
+
+        # Make sure to quit the session when we exit
+        for driver in get_drivers.__cached_drivers:
+            atexit.register(driver.quit)
+
+    return get_drivers.__cached_drivers
+
+
+class SeleniumTestCase(LiveServerTestCase):
+    #host = settings.TESTUTILS_LIVE_SERVER_TEST_CASE_HOST
+    host = '0.0.0.0'
+    port = 8000
+
+    def setUp(self):
+        super().setUp()
+        self.driver = None
+
+    def get_absolute_uri(self, url):
+        """
+        Use urljoin to take a URL which is relative to the site, build an absolute URL suitable for
+        passing to the passed webdriver and call driver.get() on it.
+
+        """
+        #return self.driver.get(urllib.parse.urljoin(self.live_server_url, url))
+        return self.driver.get(urllib.parse.urljoin('http://tox:8000/', url))
+
+    def get_reverse(self, *args, **kwargs):
+        """
+        Convenience wrapper around reverse which passes the result to :py:funf:`.get_absolute_uri`.
+
+        """
+        return self.get_absolute_uri(reverse(*args, **kwargs))

--- a/tox.ini
+++ b/tox.ini
@@ -41,6 +41,10 @@ passenv=
     DJANGO_FRONTEND_APP_BUILD_DIR
 #   Location of the coverage.xml file
     COVERAGE_XML_FILE
+#   Selenium webdriver command executir
+    TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR
+#   Browser stack access key
+    TESTUTILS_WEBDRIVER_BROWSERSTACK_ACCESS_KEY
 # Specify the default environment. Note that tox will *always* use the testsuite
 # settings unless overridden by TOX_DJANGO_SETTINGS_MODULE. Just setting
 # DJANGO_SETTINGS_MODULE will not override it.

--- a/ui/tests/test_views.py
+++ b/ui/tests/test_views.py
@@ -8,10 +8,14 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.test import override_settings
 from django.urls import reverse
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 
 import smsjwplatform.jwplatform as api
 from api.tests import create_stats_table, delete_stats_table
 from api.tests.test_views import ViewTestCase as _ViewTestCase, DELIVERY_VIDEO_FIXTURE
+from testutils.selenium import with_webdrivers, SeleniumTestCase
 
 
 class ViewTestCase(_ViewTestCase):
@@ -83,6 +87,17 @@ class MediaViewTestCase(ViewTestCase):
         self.assertTemplateUsed(r, 'ui/media.html')
         content = r.content.decode('utf8')
         self.assertIn('<script type="application/profile+json">', content)
+
+
+class HomeLiveTestCase(SeleniumTestCase):
+    @with_webdrivers
+    def test_render(self):
+        self.get_reverse('ui:home')
+        import time
+        time.sleep(20)
+        WebDriverWait(self.driver, 10).until(
+            EC.presence_of_element_located((By.ID, "app"))
+        )
 
 
 class UploadViewTestCase(ViewTestCase):


### PR DESCRIPTION
> This PR **SHOULD NOT BE MERGED**. It is a raw commit from the state of my tree at the end of the spike.

This PR documents the work I did investigating how we may integrate Selenium/Webdriver into our testing as outlined in #144. A brief summary is below followed by a list specific parts of the PR I think are of utility and ways we may wish to use them.

## Summary conclusion

**I propose that we write a stand alone end-to-end test suite which is given a URL and tests the instance of the application at that URL. This will be done as an anonymous user for the moment. The test suite can be run nightly against the test deployment on CircleCI. (This should be done in the media-deploy repo's CircleCI config.) While we're doing that, doing a nightly deploy to test would be a sensible thing to do as well.**

Although it is tempting to make end-to-end testing part of the tox test suite, I think the mechanism which is being used in this PR is brittle and prone to failure. Instead, I think it would be better to have a stand-alone end-to-end test suite which can be pointed at a deployed instance or a local development instance brought up via ``./compose.sh (development|production) up``.

## Detail

Of most interest is the new ``testutils`` application which provides a decorator for unit tests allowing them to be passed a selenium Webdriver instance for each browser we are interested in. Browserstack credentials are specified via the ``TESTUTILS_WEBDRIVER_COMMAND_EXECUTOR`` environment variable. (See the [Browserstack docs](https://www.browserstack.com/automate/python#testing-frameworks) for how to find this URL.)

In addition, a new container is added to the tox docker-compose configuration in order to allow Browserstack browsers to talk to live servers run via tox.

As a matter of plumbing, some work was done to parameterise the production Dockerfile to modify it slightly when running the test suite. Care needs to be taken here because part of the reason we want to run the tests in the production container is that we are also testing the actual container we are deploying. Having the tox container differ from production also has implications for CircleCI build times.

## Things of use

For reasons outlined above, much of the plumbing work is probably of little utility. Of greater utility is the code in the ``testutils`` module. This can be split out into a separate end-to-end test suite which can be run against a deployed instance.

## Problems

Testing a deployed instance has its own problems re authentication. Ideally we'd want to be able to test authenticated user flows as well but that has a problem in that robot accounts are currently difficult/impossible to obtain for Raven. To that end, I think we need to add a different authentication mechanism, perhaps a username/password form, which can authenticate non CRSID users. We can then add bot accounts to the deployment for testing. This has a knock-on effect for getting information on users from lookup.

At a minimum, however, there are no blockers on us writing a minimal "does it render" test for each page reachable by anonymous users.