### PR TITLE
circleci: persist documentation and coverage report

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,14 @@ jobs:
             ./compose.sh tox run -v $PWD:/tmp/workspace -e COVERAGE_FILE=/tmp/workspace/.coverage -e COVERAGE_XML_FILE=/tmp/workspace/coverage.xml -e TOXINI_ARTEFACT_DIR=/tmp/workspace/build --rm tox
             ./compose.sh tox down
 
+      - store_artifacts:
+          path: ~/project/build/htmlcov
+          destination: coverage-report
+
+      - store_artifacts:
+          path: ~/project/build/doc
+          destination: documentation
+
       - run:
           name: Run codecov
           command: codecov


### PR DESCRIPTION
Add configuration to circleci to store the built documentation and coverage report as an artifact. After this commit, the documentation and coverage reports may be viewed via the "artifact" tab in CircleCI.